### PR TITLE
BACKLOG-9012 Fix filter (for ancestors) when EQUAL is used so that it…

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FilterHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FilterHelper.java
@@ -140,6 +140,9 @@ public class FilterHelper {
 
         ALGORITHM_BY_EVALUATION.put(FieldEvaluation.AMONG, ((source, fieldName, fieldValue, fieldValues, environment) -> {
             Object value = environment.getFieldValue(source, fieldName);
+            if (value instanceof GqlJcrProperty) {
+                return fieldValues.contains(((GqlJcrProperty) value).getValue());
+            }
             return value != null && fieldValues.contains(value.toString());
         }));
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FilterHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FilterHelper.java
@@ -49,6 +49,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.relay.Connection;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.commons.lang.StringUtils;
+import org.jahia.modules.graphql.provider.dxm.node.GqlJcrProperty;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -102,6 +103,9 @@ public class FilterHelper {
     static {
         ALGORITHM_BY_EVALUATION.put(FieldEvaluation.EQUAL, ((source, fieldName, fieldValue, fieldValues, environment) -> {
             Object value = environment.getFieldValue(source, fieldName);
+            if (value instanceof GqlJcrProperty) {
+                return ((GqlJcrProperty) value).getValue().equals(fieldValue);
+            }
             return value != null && value.toString().equals(fieldValue);
         }));
 


### PR DESCRIPTION
We need this change to be able to get ancestors of a node for "Locate" functionality in Content Manager. 