### PR TITLE
BACKLOG-10433/MOD-1881

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLExtensionsProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLExtensionsProvider.java
@@ -47,10 +47,12 @@ import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.node.SpecializedType;
 import org.jahia.modules.graphql.provider.dxm.sdl.extension.FinderMixinInterface;
+import org.jahia.modules.graphql.provider.dxm.sdl.extension.PropertyFetcherExtensionInterface;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public interface DXGraphQLExtensionsProvider {
 
@@ -62,7 +64,13 @@ public interface DXGraphQLExtensionsProvider {
         return BundleScanner.getClasses(this, SpecializedType.class);
     }
 
+    // Makes it possible to add functionality to finders where GqlJCRNode from original finder is passed to the one defined as mixin
     default List<FinderMixinInterface> getFinderMixins() {
         return Collections.emptyList();
+    }
+
+    // Makes it possible to add custom property fetchers, works together with @mapping(fetcher: "yourFetcherName")
+    default Map<String, PropertyFetcherExtensionInterface> getPropertyFetchers() {
+        return Collections.emptyMap();
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -155,9 +155,9 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
 
         extensionsProviders.add(this);
 
-        sdlSchemaService.clearFinderMixins();
+        sdlSchemaService.clearExtensions();
         for (DXGraphQLExtensionsProvider extensionsProvider : extensionsProviders) {
-            sdlSchemaService.addFinderMixins(extensionsProvider.getFinderMixins());
+            sdlSchemaService.addExtensions(extensionsProvider);
             for (Class<?> aClass : extensionsProvider.getExtensions()) {
                 extensionsHandler.registerTypeExtension(aClass, container);
                 if (aClass.isAnnotationPresent(GraphQLDescription.class)) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/SDLConstants.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/SDLConstants.java
@@ -13,6 +13,9 @@ public class SDLConstants {
     public static final String CONNECTION_ARGUMENTS_SUFFIX = "Args";
     public static final String CONNECTION_ARGUMENTS_INPUT_SUFFIX = "Input";
 
+    public static final String FETCHER_DIRECTIVE = "fetcher";
+    public static final String FETCHER_DIRECTIVE_NAME = "name";
+
     private SDLConstants() {
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/extension/PropertyFetcherExtensionInterface.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/extension/PropertyFetcherExtensionInterface.java
@@ -1,0 +1,8 @@
+package org.jahia.modules.graphql.provider.dxm.sdl.extension;
+
+import graphql.schema.DataFetcher;
+import org.jahia.modules.graphql.provider.dxm.sdl.fetchers.Field;
+
+public interface PropertyFetcherExtensionInterface {
+    DataFetcher getDataFetcher(Field field);
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/FetcherDirectiveWiring.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/FetcherDirectiveWiring.java
@@ -1,0 +1,78 @@
+package org.jahia.modules.graphql.provider.dxm.sdl.parsing;
+
+import graphql.schema.*;
+import graphql.schema.idl.SchemaDirectiveWiring;
+import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
+import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
+import org.jahia.modules.graphql.provider.dxm.sdl.SDLConstants;
+import org.jahia.modules.graphql.provider.dxm.sdl.extension.PropertyFetcherExtensionInterface;
+import org.jahia.modules.graphql.provider.dxm.sdl.fetchers.Field;
+import org.jahia.modules.graphql.provider.dxm.sdl.fetchers.FinderListDataFetcher;
+import org.jahia.modules.graphql.provider.dxm.sdl.fetchers.PropertiesDataFetcherFactory;
+import org.jahia.modules.graphql.provider.dxm.sdl.fetchers.SDLPaginatedDataConnectionFetcher;
+import org.jahia.osgi.BundleUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class FetcherDirectiveWiring implements SchemaDirectiveWiring {
+
+    private static Logger logger = LoggerFactory.getLogger(FetcherDirectiveWiring.class);
+
+    @Override
+    public GraphQLObjectType onObject(SchemaDirectiveWiringEnvironment<GraphQLObjectType> environment) {
+        // Mapping on object definition -> do nothing
+        return environment.getElement();
+    }
+
+    @Override
+    public GraphQLFieldDefinition onField(SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition> environment) {
+        // Mapping on field
+
+        GraphQLFieldDefinition def = environment.getElement();
+        GraphQLDirective directive = environment.getDirective();
+
+        Field field = new Field(def.getName());
+        field.setProperty(def.getName());
+        field.setType(def.getType().getName());
+        DataFetcher typeFetcher = PropertiesDataFetcherFactory.getFetcher(def, field);
+
+        logger.debug("field name {} ", field.getName());
+        logger.debug("field type {} ", field.getType());
+
+        SDLSchemaService service = BundleUtils.getOsgiService(SDLSchemaService.class, null);
+
+        if (service != null) {
+            Map<String, PropertyFetcherExtensionInterface> fetcherExtensions = service.getPropertyFetcherExtensions();
+            String fetcherName = directive.getArgument(SDLConstants.FETCHER_DIRECTIVE_NAME).getValue().toString();
+            if (fetcherName != null && fetcherExtensions.containsKey(fetcherName)) {
+                typeFetcher = fetcherExtensions.get(fetcherName).getDataFetcher(field);
+            }
+
+
+            String parentType = environment.getNodeParentTree().getParentInfo().get().getNode().getName();
+            String key = parentType + "." + def.getName();
+            if (service.getConnectionFieldNameToSDLType().containsKey(key)) {
+                ConnectionHelper.ConnectionTypeInfo conInfo = service.getConnectionFieldNameToSDLType().get(key);
+                GraphQLOutputType node = (GraphQLOutputType) ((GraphQLList) def.getType()).getWrappedType();
+                GraphQLObjectType connectionType = ConnectionHelper.getOrCreateConnection(service, node, conInfo.getMappedToType());
+                List<GraphQLArgument> args = service.getRelay().getConnectionFieldArguments();
+                SDLPaginatedDataConnectionFetcher<GqlJcrNode> fetcher = new SDLPaginatedDataConnectionFetcher<>((FinderListDataFetcher) typeFetcher);
+
+                def.getDirectives().remove(0);
+
+                return GraphQLFieldDefinition.newFieldDefinition(def)
+                        .type(connectionType)
+                        .dataFetcher(fetcher)
+                        .argument(args)
+                        .build();
+            }
+        }
+
+        return GraphQLFieldDefinition.newFieldDefinition(def)
+                .dataFetcher(typeFetcher)
+                .build();
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLRuntimeWiring.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLRuntimeWiring.java
@@ -19,6 +19,7 @@ public class SDLRuntimeWiring {
         return RuntimeWiring.newRuntimeWiring()
                 .type(newTypeWiring("Query").build())
                 .directive(SDLConstants.MAPPING_DIRECTIVE, new MappingDirectiveWiring())
+                .directive(SDLConstants.FETCHER_DIRECTIVE, new FetcherDirectiveWiring())
                 .wiringFactory(new NoopWiringFactory() {
                     @Override
                     public DataFetcher getDefaultDataFetcher(FieldWiringEnvironment environment) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLSchemaService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLSchemaService.java
@@ -99,7 +99,7 @@ public class SDLSchemaService {
             do {
                 invalidTypes.clear();
                 sources.forEach((type, bundle) -> {
-                    SDLDefinitionStatus status = SDLTypeChecker.checkType(type, typeDefinitionRegistry);
+                    SDLDefinitionStatus status = SDLTypeChecker.checkType(this, type, typeDefinitionRegistry);
                     sdlDefinitionStatusMap.put(type.getName(), status);
                     if (status.getStatus() != SDLDefinitionStatusType.OK) {
                         invalidTypes.add(type);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatus.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatus.java
@@ -5,7 +5,7 @@ public class SDLDefinitionStatus {
     private String mapsToType;
     private String mappedTypeModuleName;
     private String mappedTypeModuleId;
-    private String statusParam;
+    private String[] statusParam;
     private SDLDefinitionStatusType statusType;
 
     public SDLDefinitionStatus(String name, SDLDefinitionStatusType status) {
@@ -13,7 +13,7 @@ public class SDLDefinitionStatus {
         this.statusType = status;
     }
 
-    public SDLDefinitionStatus(String name, SDLDefinitionStatusType status, String statusParam) {
+    public SDLDefinitionStatus(String name, SDLDefinitionStatusType status, String ...statusParam) {
         this.name = name;
         this.statusType = status;
         this.statusParam = statusParam;
@@ -31,7 +31,7 @@ public class SDLDefinitionStatus {
         this.mappedTypeModuleId = mappedTypeModuleId;
     }
 
-    public void setStatusType(SDLDefinitionStatusType statusType, String statusParam) {
+    public void setStatusType(SDLDefinitionStatusType statusType, String ...statusParam) {
         this.statusType = statusType;
         this.statusParam = statusParam;
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatusType.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatusType.java
@@ -7,7 +7,7 @@ public enum SDLDefinitionStatusType {
     MISSING_JCR_NODE_TYPE("%s node type was not found"),
     MISSING_JCR_PROPERTY("%s property is missing from node type"),
     MISSING_JCR_CHILD("%s child is missing from node type"),
-    MISSING_FETCHER("%s fetcher does not exists or is not registered"),
+    MISSING_FETCHER("fetcher %s does not exist or is not registered"),
     MISSING_FETCHER_ARGUMENT("fetcher %s argument is missing for field %s");
     private String message;
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatusType.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatusType.java
@@ -6,15 +6,16 @@ public enum SDLDefinitionStatusType {
     MISSING_TYPE("%s gql type is unavailable"),
     MISSING_JCR_NODE_TYPE("%s node type was not found"),
     MISSING_JCR_PROPERTY("%s property is missing from node type"),
-    MISSING_JCR_CHILD("%s child is missing from node type");
-
+    MISSING_JCR_CHILD("%s child is missing from node type"),
+    MISSING_FETCHER("%s fetcher does not exists or is not registered"),
+    MISSING_FETCHER_ARGUMENT("fetcher %s argument is missing for field %s");
     private String message;
 
     SDLDefinitionStatusType(String message) {
         this.message = message;
     }
 
-    public String getMessage(String param) {
+    public String getMessage(String ...param) {
         return String.format(message, param);
     }
 }


### PR DESCRIPTION
Branch used for developing new functionalities for the SDL API, allowing to declare custom fetchers, like this example from cloudinary-integration module

extend type ImageAsset {
    cloudinary: CloudinaryAsset
}

"""
Addon for Cloudinary integration
"""
type CloudinaryAsset {
    """Public identifier for Cloudinary account (null if Cloudinary settings is not configured)"""
    cloudspace: String @fetcher(name: "cloudinaryFetcher")
    """Path of the asset in Cloudinary (null if Cloudinary settings is not configured)"""
    path: String @fetcher(name: "cloudinaryFetcher")
    """Upload url for this asset (null if Cloudinary settings is not configured)"""
    url: String @fetcher(name: "cloudinaryFetcher")
}