### PR TITLE
Qa 12134

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
@@ -51,12 +51,12 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
         this.componentContext = componentContext;
         this.bundleContext.addBundleListener(this);
 
+        registerSourceMonitorService();
 
         for (Bundle bundle : bundleContext.getBundles()) {
             checkForSDLResourceInBundle(bundle, bundle.getState() == Bundle.ACTIVE ? BundleEvent.STARTED : BundleEvent.STOPPED);
         }
 
-        registerSourceMonitorService();
     }
 
     @Deactivate

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
@@ -88,24 +88,29 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
             URL url = bundle.getResource(GRAPHQL_EXTENSION_SDL);
             if (url != null) {
                 logger.debug("get bundle schema {}", url.getPath());
-                if (hasModulesMonitoringActivated) {
-                    String sourcesFolder = bundle.getHeaders().get(JAHIA_SOURCE_FOLDERS);
-                    if (sourcesFolder != null) {
-                        File file = new File(sourcesFolder + SRC_MAIN_RESOURCES + GRAPHQL_EXTENSION_SDL);
-                        if (file.exists()) {
-                            try {
-                                url = file.toURI().toURL();
-                            } catch (MalformedURLException e) {
-                                logger.error(e.getMessage(), e);
-                            }
-                        }
-                    }
-                }
+                url = getSourcesUrl(bundle, url);
                 registerSDLResource(eventType, bundle.getSymbolicName(), url);
                 return true;
             }
         }
         return false;
+    }
+
+    private URL getSourcesUrl(Bundle bundle, URL url) {
+        if (hasModulesMonitoringActivated) {
+            String sourcesFolder = bundle.getHeaders().get(JAHIA_SOURCE_FOLDERS);
+            if (sourcesFolder != null) {
+                File file = new File(sourcesFolder + SRC_MAIN_RESOURCES + GRAPHQL_EXTENSION_SDL);
+                if (file.exists()) {
+                    try {
+                        url = file.toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        logger.error(e.getMessage(), e);
+                    }
+                }
+            }
+        }
+        return url;
     }
 
     /**
@@ -119,13 +124,13 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
         switch (bundleEventType) {
             case BundleEvent.STARTED:
                 if (!sdlResources.containsKey(bundleName)) {
-                    logger.debug("add new type registry for " + bundleName);
+                    logger.debug("add new type registry for {}", bundleName);
                     sdlResources.put(bundleName, sdlResource);
                 }
                 break;
             default:
                 if (sdlResources.containsKey(bundleName)) {
-                    logger.debug("remove type registry for " + bundleName);
+                    logger.debug("remove type registry for {}", bundleName);
                     sdlResources.remove(bundleName);
                 }
         }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/registration/SDLRegistrationImpl.java
@@ -4,6 +4,7 @@ import org.jahia.modules.external.modules.osgi.ModulesSourceMonitor;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.sdl.monitor.SDLFileSourceMonitor;
 import org.jahia.osgi.BundleUtils;
+import org.jahia.registries.ServicesRegistry;
 import org.osgi.framework.*;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -21,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Component(service = SDLRegistrationService.class, immediate = true)
 public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousBundleListener {
-    private final static Logger logger = LoggerFactory.getLogger(SDLRegistrationImpl.class);
+    private static final String EXTERNAL_PROVIDER_MODULES = "external-provider-modules";
+    private static final Logger logger = LoggerFactory.getLogger(SDLRegistrationImpl.class);
     private static final String JAHIA_SOURCE_FOLDERS = "Jahia-Source-Folders";
     private static final String SRC_MAIN_RESOURCES = "/src/main/resources/";
     private static final String GRAPHQL_EXTENSION_SDL = "META-INF/graphql-extension.sdl";
@@ -42,7 +44,6 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
     private final Map<String, URL> sdlResources = new ConcurrentHashMap<>();
     private BundleContext bundleContext;
     private ComponentContext componentContext;
-    private Boolean hasModulesMonitoringActivated = Boolean.FALSE;
     private ServiceRegistration<ModulesSourceMonitor> serviceRegistration = null;
 
     @Activate
@@ -52,11 +53,9 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
         this.bundleContext.addBundleListener(this);
 
         registerSourceMonitorService();
+        registerAllBundles(isSourcesAvailable());
 
-        for (Bundle bundle : bundleContext.getBundles()) {
-            checkForSDLResourceInBundle(bundle, bundle.getState() == Bundle.ACTIVE ? BundleEvent.STARTED : BundleEvent.STOPPED);
-        }
-
+        BundleUtils.getBundleBySymbolicName(EXTERNAL_PROVIDER_MODULES, null);
     }
 
     @Deactivate
@@ -69,27 +68,47 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
         return sdlResources;
     }
 
-    @Override
-    public void bundleChanged(BundleEvent event) {
-        int eventType = event.getType();
+    private boolean isSourcesAvailable() {
+        return ServicesRegistry.getInstance().getJahiaTemplateManagerService().getTemplatePackageById(EXTERNAL_PROVIDER_MODULES) != null;
+    }
 
-        if (eventType == BundleEvent.STARTED || eventType == BundleEvent.STOPPED) {
-            Bundle bundle = event.getBundle();
-            if (checkForSDLResourceInBundle(bundle, event.getType())) {
-                logger.debug("received event {} for bundle {} ", status.get(eventType), event.getBundle().getSymbolicName());
-                componentContext.disableComponent(DXGraphQLProvider.class.getName());
-                componentContext.enableComponent(DXGraphQLProvider.class.getName());
-            }
+    private void registerAllBundles(boolean sourcesAvailable) {
+        sdlResources.clear();
+        for (Bundle bundle : bundleContext.getBundles()) {
+            checkForSDLResourceInBundle(bundle, bundle.getState() == Bundle.ACTIVE, sourcesAvailable);
         }
     }
 
-    private boolean checkForSDLResourceInBundle(Bundle bundle, int eventType) {
+    @Override
+    public void bundleChanged(BundleEvent event) {
+        int eventType = event.getType();
+        Bundle bundle = event.getBundle();
+        boolean restart = false;
+        if (eventType == BundleEvent.STARTED || eventType == BundleEvent.STOPPED) {
+            if (bundle.getSymbolicName().equals(EXTERNAL_PROVIDER_MODULES)) {
+                logger.debug("received event {} for bundle {}, reloading all sdl", status.get(eventType), bundle.getSymbolicName());
+                registerAllBundles(eventType == BundleEvent.STARTED);
+                restart = true;
+            } else if (checkForSDLResourceInBundle(bundle, eventType == BundleEvent.STARTED, isSourcesAvailable())) {
+                logger.debug("received event {} for bundle {} ", status.get(eventType), bundle.getSymbolicName());
+                restart = true;
+            }
+        }
+        if (restart) {
+            componentContext.disableComponent(DXGraphQLProvider.class.getName());
+            componentContext.enableComponent(DXGraphQLProvider.class.getName());
+        }
+    }
+
+    private boolean checkForSDLResourceInBundle(Bundle bundle, boolean register, boolean withSources) {
         if (BundleUtils.isJahiaBundle(bundle)) {
             URL url = bundle.getResource(GRAPHQL_EXTENSION_SDL);
             if (url != null) {
                 logger.debug("get bundle schema {}", url.getPath());
-                url = getSourcesUrl(bundle, url);
-                registerSDLResource(eventType, bundle.getSymbolicName(), url);
+                if (withSources) {
+                    url = getSourcesUrl(bundle, url);
+                }
+                handleSDLResource(register, bundle.getSymbolicName(), url);
                 return true;
             }
         }
@@ -97,16 +116,14 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
     }
 
     private URL getSourcesUrl(Bundle bundle, URL url) {
-        if (hasModulesMonitoringActivated) {
-            String sourcesFolder = bundle.getHeaders().get(JAHIA_SOURCE_FOLDERS);
-            if (sourcesFolder != null) {
-                File file = new File(sourcesFolder + SRC_MAIN_RESOURCES + GRAPHQL_EXTENSION_SDL);
-                if (file.exists()) {
-                    try {
-                        url = file.toURI().toURL();
-                    } catch (MalformedURLException e) {
-                        logger.error(e.getMessage(), e);
-                    }
+        String sourcesFolder = bundle.getHeaders().get(JAHIA_SOURCE_FOLDERS);
+        if (sourcesFolder != null) {
+            File file = new File(sourcesFolder + SRC_MAIN_RESOURCES + GRAPHQL_EXTENSION_SDL);
+            if (file.exists()) {
+                try {
+                    url = file.toURI().toURL();
+                } catch (MalformedURLException e) {
+                    logger.error(e.getMessage(), e);
                 }
             }
         }
@@ -116,30 +133,27 @@ public class SDLRegistrationImpl implements SDLRegistrationService, SynchronousB
     /**
      * Registers or deregisters a bundle's graphql-extension.sdl in the sdl registry
      *
-     * @param bundleEventType - Current state of the bundle
+     * @param register        - Register or unregister
      * @param bundleName      - Name of the bundle
      * @param sdlResource     - URL resource pointing to SDL file (graphql-extension.sdl) in bundle
      */
-    private void registerSDLResource(int bundleEventType, String bundleName, final URL sdlResource) {
-        switch (bundleEventType) {
-            case BundleEvent.STARTED:
-                if (!sdlResources.containsKey(bundleName)) {
-                    logger.debug("add new type registry for {}", bundleName);
-                    sdlResources.put(bundleName, sdlResource);
-                }
-                break;
-            default:
-                if (sdlResources.containsKey(bundleName)) {
-                    logger.debug("remove type registry for {}", bundleName);
-                    sdlResources.remove(bundleName);
-                }
+    private void handleSDLResource(boolean register, String bundleName, final URL sdlResource) {
+        if (register) {
+            if (!sdlResources.containsKey(bundleName)) {
+                logger.debug("add new type registry for {}", bundleName);
+                sdlResources.put(bundleName, sdlResource);
+            }
+        } else {
+            if (sdlResources.containsKey(bundleName)) {
+                logger.debug("remove type registry for {}", bundleName);
+                sdlResources.remove(bundleName);
+            }
         }
     }
 
     private void registerSourceMonitorService() {
         try {
             serviceRegistration = bundleContext.registerService(ModulesSourceMonitor.class, new SDLFileSourceMonitor(bundleContext, componentContext), null);
-            hasModulesMonitoringActivated = Boolean.TRUE;
         } catch (NoClassDefFoundError e) {
             if (logger.isDebugEnabled()) {
                 logger.error(e.getMessage(), e);


### PR DESCRIPTION
- Try to register only on module startup. Do not need to check or get a "external-provider-modules" bundle, just rely on OSGi to find the ModulesSourceMonitor class
- Do not unregister when an external-provider-modules bundle is stopped - it's useless, and can be an issue when you have multiple versions of it
- For the same reason, do not register when an external-provider-modules bundle is started.
- If external-provider-modules is installed and resolved after graphql-dxm-provider is started, the latter should anyway be refreshed to find the ModulesSourceMonitor class, so nothing can be done in a BundleListener.
- Also, in the case external-provider-modules is stopped , we should not look into the sources anymore - this was not working, as the bundles were not parsed again when the state of external-provider-modules changed. I changed the code to handle start/stop of external-provider-modules - when it is stopped, sources are not used. Use ServiceRegistry instead of BundleUtils.getBundleBySymbolicName() to avoid issues with multiple versions of the bundle.