### PR TITLE
BACKLOG-15343-jahia-7.3: Fix race condition on GraphQLPublicationTest

### DIFF
--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>king-http-client</artifactId>
             <version>3.0.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLPublicationTest.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLPublicationTest.java
@@ -43,6 +43,7 @@
  */
 package org.jahia.test.graphql;
 
+import org.awaitility.core.ConditionFactory;
 import org.jahia.api.Constants;
 import org.jahia.exceptions.JahiaException;
 import org.jahia.exceptions.JahiaRuntimeException;
@@ -67,12 +68,17 @@ import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.util.*;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.*;
+import static org.awaitility.Duration.ONE_SECOND;
+
 public class GraphQLPublicationTest extends GraphQLTestSupport {
 
     @Rule public TestName name = new TestName();
 
 
     private static final long TIMEOUT_WAITING_FOR_PUBLICATION = 5000;
+    private static final String PUBLICATION_JOB_NAME = "PublicationJob";
     private static final String TESTSITE_NAME = "graphqlPublicationTestSite";
 
     private JCRSessionWrapper defaultSession;
@@ -167,16 +173,7 @@ public class GraphQLPublicationTest extends GraphQLTestSupport {
                 + "}"
         );
 
-        SchedulerService schedulerService = BundleUtils.getOsgiService(SchedulerService.class, null);
-
-        long startedWaitingAt = System.currentTimeMillis();
-
-        // Wait until the node is published via a background job.
-        while(schedulerService.getAllActiveJobs().stream().anyMatch(job -> job.getDescription().equals("Publication"))){
-            if (System.currentTimeMillis() - startedWaitingAt > TIMEOUT_WAITING_FOR_PUBLICATION) {
-                Assert.fail("Timeout waiting for node to be published");
-            }
-        }
+        waitForPublicationToFinish();
 
         JSONObject mutationResult = result.getJSONObject("data").getJSONObject("jcr").getJSONObject("mutateNode");
         Assert.assertTrue(mutationResult.getBoolean("publish"));
@@ -293,5 +290,16 @@ public class GraphQLPublicationTest extends GraphQLTestSupport {
 
         defaultSession.save();
         return site;
+    }
+
+    private void waitForPublicationToFinish() {
+        SchedulerService schedulerService = BundleUtils.getOsgiService(SchedulerService.class, null);
+
+        final ConditionFactory conditionFactory = with().pollInterval(ONE_SECOND).await()
+                .atMost(TIMEOUT_WAITING_FOR_PUBLICATION, MILLISECONDS);
+        conditionFactory.until(() -> Arrays.stream(schedulerService.getScheduler().getTriggerNames(SchedulerService.INSTANT_TRIGGER_GROUP))
+                .noneMatch(triggerName -> triggerName.contains(PUBLICATION_JOB_NAME)));
+        conditionFactory.until(() -> schedulerService.getAllActiveJobs().stream()
+                .noneMatch(job -> job.getJobClass().getName().contains(PUBLICATION_JOB_NAME)));
     }
 }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15343

## Description

Fix race condition that's happening on GraphQLPublicationTest

## Tests

The following are included in this PR
- [x] Integration Tests

Note:
Same pr as https://github.com/Jahia/graphql-core/pull/88/files
