### PR TITLE
Backlog 15726 - Adding more nodes to the admin node in graphql

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -67,7 +67,7 @@ public class GqlAdminQuery {
     /**
      * Get Build Datetime
      *
-     * @return String datetime
+     * @return String datetime in ISO8601 format
      */
     @GraphQLField
     @GraphQLName("datetime")

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -5,6 +5,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
 import org.jahia.bin.Jahia;
+import org.jahia.api.Constants;
 
 /**
  * GraphQL root object for Admin related queries.
@@ -12,6 +13,11 @@ import org.jahia.bin.Jahia;
 @GraphQLName("adminQuery")
 @GraphQLDescription("Admin queries root")
 public class GqlAdminQuery {
+
+    /**
+     * @deprecated replaced by jahia node
+     */
+    @Deprecated
     @GraphQLField
     @GraphQLName("version")
     @GraphQLNonNull
@@ -19,4 +25,29 @@ public class GqlAdminQuery {
     public String getProductVersion() {
         return Jahia.getFullProductVersion();
     }
+
+
+    /**
+     * Get getJahiaVersion
+     *
+     * @return GqlJahiaVersion
+     */
+    @GraphQLField
+    @GraphQLName("jahia")
+    @GraphQLDescription("Version of the running Jahia instance")
+    public GqlJahiaVersion getJahiaVersion() {
+        return new GqlJahiaVersion(
+                Constants.JAHIA_PROJECT_VERSION,
+                String.valueOf(Jahia.getBuildNumber()),
+                Constants.JAHIA_PROJECT_VERSION.contains("SNAPSHOT")
+        );
+    }
+
+    @GraphQLField
+    @GraphQLName("datetime")
+    @GraphQLDescription("Build Datetime of the running Jahia instance")
+    public String getDatetime() {
+        return Jahia.getBuildDate();
+    }
+
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -9,7 +9,6 @@ import org.jahia.api.Constants;
 import org.jahia.bin.Jahia;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Calendar;
@@ -52,7 +51,7 @@ public class GqlAdminQuery {
         gqlJahiaVersion.setBuild(String.valueOf(Jahia.getBuildNumber()));
         gqlJahiaVersion.setSnapshot(Constants.JAHIA_PROJECT_VERSION.contains("SNAPSHOT"));
 
-        //Formatting buildDate
+        //Formatting buildDate to ISO8601
         Date date = null;
         try {
             date = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.ENGLISH).parse(Jahia.getBuildDate());

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -7,6 +7,9 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import org.apache.jackrabbit.util.ISO8601;
 import org.jahia.api.Constants;
 import org.jahia.bin.Jahia;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Calendar;
@@ -19,6 +22,8 @@ import java.util.Locale;
 @GraphQLName("adminQuery")
 @GraphQLDescription("Admin queries root")
 public class GqlAdminQuery {
+
+    public static final Logger logger = LoggerFactory.getLogger(GqlAdminQuery.class);
 
     /**
      * @deprecated replaced by jahia node
@@ -55,7 +60,7 @@ public class GqlAdminQuery {
             calendar.setTime(date);
             gqlJahiaVersion.setBuildDate(ISO8601.format(calendar));
         } catch (ParseException e) {
-            e.printStackTrace();
+            logger.warn("Exception while parsing build date",e);
         }
         return gqlJahiaVersion;
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -49,7 +49,7 @@ public class GqlAdminQuery {
      */
     @GraphQLField
     @GraphQLName("datetime")
-    @GraphQLDescription("Build Datetime of the running Jahia instance")
+    @GraphQLDescription("Build datetime of the running Jahia instance")
     public String getDatetime() {
         return Jahia.getBuildDate();
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -4,8 +4,14 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
-import org.jahia.bin.Jahia;
+import org.apache.jackrabbit.util.ISO8601;
 import org.jahia.api.Constants;
+import org.jahia.bin.Jahia;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * GraphQL root object for Admin related queries.
@@ -34,12 +40,24 @@ public class GqlAdminQuery {
     @GraphQLField
     @GraphQLName("jahia")
     @GraphQLDescription("Version of the running Jahia instance")
-    public GqlJahiaVersion getJahiaVersion() {
-        return new GqlJahiaVersion(
-                Constants.JAHIA_PROJECT_VERSION,
-                String.valueOf(Jahia.getBuildNumber()),
-                Constants.JAHIA_PROJECT_VERSION.contains("SNAPSHOT")
-        );
+    public GqlJahiaVersion getJahiaVersion()  {
+
+        GqlJahiaVersion gqlJahiaVersion = new GqlJahiaVersion();
+        gqlJahiaVersion.setRelease(Constants.JAHIA_PROJECT_VERSION);
+        gqlJahiaVersion.setBuild(String.valueOf(Jahia.getBuildNumber()));
+        gqlJahiaVersion.setSnapshot(Constants.JAHIA_PROJECT_VERSION.contains("SNAPSHOT"));
+
+        //Formatting buildDate
+        Date date = null;
+        try {
+            date = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.ENGLISH).parse(Jahia.getBuildDate());
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(date);
+            gqlJahiaVersion.setBuildDate(ISO8601.format(calendar));
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return gqlJahiaVersion;
     }
 
     /**
@@ -49,9 +67,9 @@ public class GqlAdminQuery {
      */
     @GraphQLField
     @GraphQLName("datetime")
-    @GraphQLDescription("Build datetime of the running Jahia instance")
+    @GraphQLDescription("Current datetime")
     public String getDatetime() {
-        return Jahia.getBuildDate();
+        return ISO8601.format(Calendar.getInstance());
     }
 
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -26,7 +26,6 @@ public class GqlAdminQuery {
         return Jahia.getFullProductVersion();
     }
 
-
     /**
      * Get getJahiaVersion
      *
@@ -43,6 +42,11 @@ public class GqlAdminQuery {
         );
     }
 
+    /**
+     * Get Build Datetime
+     *
+     * @return String datetime
+     */
     @GraphQLField
     @GraphQLName("datetime")
     @GraphQLDescription("Build Datetime of the running Jahia instance")

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
@@ -1,0 +1,75 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+public class GqlJahiaVersion {
+
+    private String release;
+    private String build;
+    private boolean snapshot;
+
+    public GqlJahiaVersion() {
+    }
+
+    public GqlJahiaVersion(String release, String build, boolean snapshot) {
+        this.release = release;
+        this.build = build;
+        this.snapshot = snapshot;
+    }
+
+    @GraphQLField
+    @GraphQLName("release")
+    public String getRelease() {
+        return release;
+    }
+
+    @GraphQLField
+    @GraphQLName("build")
+    public String getBuild() {
+        return build;
+    }
+
+    @GraphQLField
+    @GraphQLName("isSnapshot")
+    public boolean isSnapshot() {
+        return snapshot;
+    }
+
+    public void setRelease(String release) {
+        this.release = release;
+    }
+
+    public void setBuild(String build) {
+        this.build = build;
+    }
+
+    public void setSnapshot(boolean snapshot) {
+        this.snapshot = snapshot;
+    }
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
@@ -23,6 +23,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.admin;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 
@@ -40,18 +41,21 @@ public class GqlJahiaVersion {
 
     @GraphQLField
     @GraphQLName("release")
+    @GraphQLDescription("Release of the running Jahia instance")
     public String getRelease() {
         return release;
     }
 
     @GraphQLField
     @GraphQLName("build")
+    @GraphQLDescription("Build number of the running Jahia instance")
     public String getBuild() {
         return build;
     }
 
     @GraphQLField
     @GraphQLName("isSnapshot")
+    @GraphQLDescription("Flag returning if running Jahia instance is a SNAPSHOT")
     public boolean isSnapshot() {
         return snapshot;
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
@@ -31,11 +31,16 @@ public class GqlJahiaVersion {
 
     private String release;
     private String build;
+    private String buildDate;
     private boolean snapshot;
 
-    public GqlJahiaVersion(String release, String build, boolean snapshot) {
+    public GqlJahiaVersion() {
+    }
+
+    public GqlJahiaVersion(String release, String build, String buildDate, boolean snapshot) {
         this.release = release;
         this.build = build;
+        this.buildDate = buildDate;
         this.snapshot = snapshot;
     }
 
@@ -54,12 +59,34 @@ public class GqlJahiaVersion {
     }
 
     @GraphQLField
+    @GraphQLName("buildDate")
+    @GraphQLDescription("Build date of the running Jahia instance")
+    public String getBuildDate() {
+        return buildDate;
+    }
+
+    @GraphQLField
     @GraphQLName("isSnapshot")
     @GraphQLDescription("Flag returning if running Jahia instance is a SNAPSHOT")
     public boolean isSnapshot() {
         return snapshot;
     }
 
+    public void setRelease(String release) {
+        this.release = release;
+    }
+
+    public void setBuild(String build) {
+        this.build = build;
+    }
+
+    public void setBuildDate(String buildDate) {
+        this.buildDate = buildDate;
+    }
+
+    public void setSnapshot(boolean snapshot) {
+        this.snapshot = snapshot;
+    }
 }
 
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
@@ -32,9 +32,6 @@ public class GqlJahiaVersion {
     private String build;
     private boolean snapshot;
 
-    public GqlJahiaVersion() {
-    }
-
     public GqlJahiaVersion(String release, String build, boolean snapshot) {
         this.release = release;
         this.build = build;
@@ -59,17 +56,6 @@ public class GqlJahiaVersion {
         return snapshot;
     }
 
-    public void setRelease(String release) {
-        this.release = release;
-    }
-
-    public void setBuild(String build) {
-        this.build = build;
-    }
-
-    public void setSnapshot(boolean snapshot) {
-        this.snapshot = snapshot;
-    }
 }
 
 


### PR DESCRIPTION
-Add more nodes to the admin node in graphql
-Deprecated old version node

## JIRA

https://jira.jahia.org/browse/BACKLOG-15726

## Description

Today our admin node returns the full Jahia version which requires some parsing on the client-side to fetch relevant information.

Before:

```GraphQL
{
  "data": {
    "admin": {
      "version": "Jahia 8.0.3.0 [Indigo] - Build 61002"
    }
  }
}
```

After changes:

```GraphQL
{
  "data": {
    "admin": {
      "version": "Jahia 8.0.2.0 - Enterprise Distribution",
      "jahia": {
        "release": "8.0.0.0",
        "build": "60910",
        "buildDate": "2021-02-02T17:08:30.000-05:00",
        "isSnapshot": false
      },
      "datetime": "2021-03-16T15:36:42.902-04:00"
    }
  }
}
```

