### PR TITLE
Update CircleCI nightly config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,7 +437,7 @@ workflows:
           RUN_TESTSIMAGE: << pipeline.parameters.TESTS_IMAGE >>:latest
           TOOLS_USER: root
           TOOLS_PWD: root
-          MANIFEST: warmup-manifest-release.yml
+          MANIFEST: warmup-manifest-build.yml
           TESTRAIL_MILESTONE: Jahia-Latest
           SKIP_TESTRAIL: "true"
           SKIP_ARTIFACTS: false
@@ -467,16 +467,27 @@ workflows:
     jobs:
       - initialize
       - integration_tests:
-          matrix:
-            parameters:
-              JAHIA_IMAGE: ["jahia/jahia-private:snapshot-dev", "jahia/jahia-dev:8.0"]
-              RUN_TESTSIMAGE: ["<< pipeline.parameters.TESTS_IMAGE >>:latest"]
-              MANIFEST: ["warmup-manifest-snapshot.yml"]
-              TESTRAIL_MILESTONE: ["<< matrix.JAHIA_IMAGE >>"]
-              TOOLS_USER: ["root"]
-              TOOLS_PWD: ["root"]
-          name: Nightly-<< matrix.JAHIA_IMAGE >>
+          parameters:
+            JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
+            RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
+            MANIFEST: "warmup-manifest-snapshot.yml"
+            TESTRAIL_MILESTONE: "<< JAHIA_IMAGE >>"
+            TOOLS_USER: "root"
+            TOOLS_PWD: "root"
+          name: Nightly-snapshot<< JAHIA_IMAGE >>
           context: QA_ENVIRONMENT
           requires:
             - initialize
- 
+      - integration_tests:
+          matrix:
+          parameters:
+            JAHIA_IMAGE: "jahia/jahia-dev:8.0"
+            RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
+            MANIFEST: "warmup-manifest-release.yml"
+            TESTRAIL_MILESTONE: "<< JAHIA_IMAGE >>"
+            TOOLS_USER: "root"
+            TOOLS_PWD: "root"
+          name: Nightly-release-<< JAHIA_IMAGE >>
+          context: QA_ENVIRONMENT
+          requires:
+            - initialize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,10 +471,10 @@ workflows:
             JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
             RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
             MANIFEST: "warmup-manifest-snapshot.yml"
-            TESTRAIL_MILESTONE: "<< JAHIA_IMAGE >>"
+            TESTRAIL_MILESTONE: "<< parameters.JAHIA_IMAGE >>"
             TOOLS_USER: "root"
             TOOLS_PWD: "root"
-          name: Nightly-snapshot<< JAHIA_IMAGE >>
+          name: Nightly-<< parameters.JAHIA_IMAGE >>
           context: QA_ENVIRONMENT
           requires:
             - initialize
@@ -484,10 +484,10 @@ workflows:
             JAHIA_IMAGE: "jahia/jahia-dev:8.0"
             RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
             MANIFEST: "warmup-manifest-release.yml"
-            TESTRAIL_MILESTONE: "<< JAHIA_IMAGE >>"
+            TESTRAIL_MILESTONE: "<< parameters.JAHIA_IMAGE >>"
             TOOLS_USER: "root"
             TOOLS_PWD: "root"
-          name: Nightly-release-<< JAHIA_IMAGE >>
+          name: Nightly-<< parameters.JAHIA_IMAGE >>
           context: QA_ENVIRONMENT
           requires:
             - initialize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,7 +479,6 @@ workflows:
           requires:
             - initialize
       - integration_tests:
-          matrix:
           parameters:
             JAHIA_IMAGE: "jahia/jahia-dev:8.0"
             RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,25 +467,23 @@ workflows:
     jobs:
       - initialize
       - integration_tests:
-          parameters:
-            JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
-            RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
-            MANIFEST: "warmup-manifest-snapshot.yml"
-            TESTRAIL_MILESTONE: Jahia-Latest-Snapshot"
-            TOOLS_USER: "root"
-            TOOLS_PWD: "root"
+          JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
+          RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
+          MANIFEST: "warmup-manifest-snapshot.yml"
+          TESTRAIL_MILESTONE: Jahia-Latest-Snapshot"
+          TOOLS_USER: "root"
+          TOOLS_PWD: "root"
           name: Nightly-Jahia-Latest-Snapshot
           context: QA_ENVIRONMENT
           requires:
             - initialize
       - integration_tests:
-          parameters:
-            JAHIA_IMAGE: "jahia/jahia-dev:8.0"
-            RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
-            MANIFEST: "warmup-manifest-release.yml"
-            TESTRAIL_MILESTONE: Jahia-Latest-Release
-            TOOLS_USER: "root"
-            TOOLS_PWD: "root"
+          JAHIA_IMAGE: "jahia/jahia-dev:8.0"
+          RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
+          MANIFEST: "warmup-manifest-release.yml"
+          TESTRAIL_MILESTONE: Jahia-Latest-Release
+          TOOLS_USER: "root"
+          TOOLS_PWD: "root"
           name: Nightly-Jahia-Latest-Release
           context: QA_ENVIRONMENT
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,10 +471,10 @@ workflows:
             JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
             RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
             MANIFEST: "warmup-manifest-snapshot.yml"
-            TESTRAIL_MILESTONE: "<< parameters.JAHIA_IMAGE >>"
+            TESTRAIL_MILESTONE: Jahia-Latest-Snapshot"
             TOOLS_USER: "root"
             TOOLS_PWD: "root"
-          name: Nightly-<< parameters.JAHIA_IMAGE >>
+          name: Nightly-Jahia-Latest-Snapshot
           context: QA_ENVIRONMENT
           requires:
             - initialize
@@ -484,10 +484,10 @@ workflows:
             JAHIA_IMAGE: "jahia/jahia-dev:8.0"
             RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
             MANIFEST: "warmup-manifest-release.yml"
-            TESTRAIL_MILESTONE: "<< parameters.JAHIA_IMAGE >>"
+            TESTRAIL_MILESTONE: Jahia-Latest-Release
             TOOLS_USER: "root"
             TOOLS_PWD: "root"
-          name: Nightly-<< parameters.JAHIA_IMAGE >>
+          name: Nightly-Jahia-Latest-Release
           context: QA_ENVIRONMENT
           requires:
             - initialize

--- a/tests/warmup-manifest-build.yml
+++ b/tests/warmup-manifest-build.yml
@@ -4,7 +4,7 @@ jobs:
     fetch: http
     username: NEXUS_USERNAME
     password: NEXUS_PASSWORD
-    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.test&a=jahia-test-module&v=JAHIA_VERSION
+    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.test&a=jahia-test-module&v=JAHIA_VERSION-SNAPSHOT
     filepath: /tmp/jahia-test-module-JAHIA_VERSION.jar
   - type: module
     id: jahia-test-module

--- a/tests/warmup-manifest-release.yml
+++ b/tests/warmup-manifest-release.yml
@@ -9,9 +9,15 @@ jobs:
   - type: module
     id: jahia-test-module
     filepath: /tmp/jahia-test-module-JAHIA_VERSION.jar
-  - type: module
-    id: graphql-dxm-provider
+  - type: asset
+    fetch: http
+    username: NEXUS_USERNAME
+    password: NEXUS_PASSWORD
+    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.modules&a=graphql-dxm-provider&v=LATEST
     filepath: /tmp/artifacts/graphql-dxm-provider-SNAPSHOT.jar
-  - type: module
-    id: graphql-test
+  - type: asset
+    fetch: http
+    username: NEXUS_USERNAME
+    password: NEXUS_PASSWORD
+    source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.test&a=graphql-test&v=LATEST
     filepath: /tmp/artifacts/graphql-test-SNAPSHOT.jar


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Update the config to fix the nightly executions. As the test module is linked to the Jahia version the matrix configuration cannot work for that, as we need to retrieve the snapshot or the release version of the module which cannot be done in the warmup. That's why I've updated the workflow.