### PR TITLE
Remove call to specific snapshot version in int. tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,7 +433,7 @@ workflows:
             - build
           context: QA_ENVIRONMENT
           #Using Aliases here (8 is the latest of the 8 tree, 8.1 is the latest of the tree, ...)
-          JAHIA_IMAGE: jahia/jahia-dev:8.0.1.0
+          JAHIA_IMAGE: jahia/jahia-private:snapshot-dev
           RUN_TESTSIMAGE: << pipeline.parameters.TESTS_IMAGE >>:latest
           TOOLS_USER: root
           TOOLS_PWD: root


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

The integration were explicitly using the 8.0.1.0-SNAPSHOT image. As we use this version to get the jahia-test-module it will stop working as soon as the artifacts will be clean-up in Nexus