### PR TITLE
Adding description to jahiaVersion node

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaVersion.java
@@ -27,6 +27,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 
+@GraphQLDescription("Version of the running Jahia instance")
 public class GqlJahiaVersion {
 
     private String release;


### PR DESCRIPTION
Simply adding graphql description to JahiaVersion Node

## JIRA

https://jira.jahia.org/browse/BACKLOG-15758

## Description

Before:
We have a missing description in recent API changes.

You can easily find it by looking at the schema which is fetch by graphql playground (look via dev console) when you open it up on a Jahia instance.

Then search for: GqlJahiaVersion

After Change:

![image](https://user-images.githubusercontent.com/4117549/112524218-f4a3d600-8d75-11eb-9ba4-1388d02b59c1.png)
