### PR TITLE
Remove the double quotes in the nightly config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,23 +467,23 @@ workflows:
     jobs:
       - initialize
       - integration_tests:
-          JAHIA_IMAGE: "jahia/jahia-private:snapshot-dev"
-          RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
-          MANIFEST: "warmup-manifest-snapshot.yml"
-          TESTRAIL_MILESTONE: Jahia-Latest-Snapshot"
-          TOOLS_USER: "root"
-          TOOLS_PWD: "root"
+          JAHIA_IMAGE: jahia/jahia-private:snapshot-dev
+          RUN_TESTSIMAGE: << pipeline.parameters.TESTS_IMAGE >>:latest
+          MANIFEST: warmup-manifest-snapshot.yml
+          TESTRAIL_MILESTONE: Jahia-Latest-Snapshot
+          TOOLS_USER: root
+          TOOLS_PWD: root
           name: Nightly-Jahia-Latest-Snapshot
           context: QA_ENVIRONMENT
           requires:
             - initialize
       - integration_tests:
-          JAHIA_IMAGE: "jahia/jahia-dev:8.0"
-          RUN_TESTSIMAGE: "<< pipeline.parameters.TESTS_IMAGE >>:latest"
-          MANIFEST: "warmup-manifest-release.yml"
+          JAHIA_IMAGE: jahia/jahia-dev:8.0
+          RUN_TESTSIMAGE: << pipeline.parameters.TESTS_IMAGE >>:latest
+          MANIFEST: warmup-manifest-release.yml
           TESTRAIL_MILESTONE: Jahia-Latest-Release
-          TOOLS_USER: "root"
-          TOOLS_PWD: "root"
+          TOOLS_USER: root
+          TOOLS_PWD: root
           name: Nightly-Jahia-Latest-Release
           context: QA_ENVIRONMENT
           requires:


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

It appeared that some quotes were causing issues in Testrail or Jahia. They were not removed when I moved from matrix to non-matrix config