### PR TITLE
Add missing steps to deploy the downloaded artifacts

### DIFF
--- a/tests/warmup-manifest-snapshot.yml
+++ b/tests/warmup-manifest-snapshot.yml
@@ -15,9 +15,15 @@ jobs:
     password: NEXUS_PASSWORD
     source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.modules&a=graphql-dxm-provider&v=LATEST
     filepath: /tmp/artifacts/graphql-dxm-provider-SNAPSHOT.jar
+  - type: module
+    id: graphql-dxm-provider
+    filepath: /tmp/artifacts/graphql-dxm-provider-SNAPSHOT.jar
   - type: asset
     fetch: http
     username: NEXUS_USERNAME
     password: NEXUS_PASSWORD
     source: https://devtools.jahia.com/nexus/service/local/artifact/maven/redirect?r=jahia-snapshots&g=org.jahia.test&a=graphql-test&v=LATEST
+    filepath: /tmp/artifacts/graphql-test-SNAPSHOT.jar
+  - type: module
+    id: graphql-test
     filepath: /tmp/artifacts/graphql-test-SNAPSHOT.jar


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

After a couple of failing nightly runs I figured out that the warmup file (for snapshot) was missing the steps to deploy the downloaded assets 