### PR TITLE
BACKLOG-16000: Add annotation to setup permission configuration, restore admin fields (#120)

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -73,7 +73,7 @@
         </export-package>
         <jahia.modules.importPackage>!org.jahia.modules.graphql.provider.dxm.sdl,!org.jahia.modules.graphql.provider.dxm.sdl.extension,!org.jahia.modules.graphql.provider.dxm.osgi.annotations</jahia.modules.importPackage>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MC0CFQCL7z5tVdV7YEuf53QotSXeU6QeRwIUTU+LhaFuUc9tVS+kdtlcVTJkPCw=</jahia-module-signature>
+        <jahia-module-signature>MCwCFC3YySHa7rppNm6CR0wqPSL8QNghAhQ9ocWsznf9yREAxBJZBEM+LCzLwQ==</jahia-module-signature>
         <mockito.version>2.21.0</mockito.version>
         <powermock.version>2.0.7</powermock.version>
     </properties>

--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -68,6 +68,7 @@
             org.jahia.modules.graphql.provider.dxm.sdl.extension,
             org.jahia.modules.graphql.provider.dxm.sdl.fetchers,
             org.jahia.modules.graphql.provider.dxm.sdl,
+            org.jahia.modules.graphql.provider.dxm.security,
             org.jahia.modules.graphql.provider.dxm.user,
             org.jahia.modules.graphql.provider.dxm.osgi.annotations
         </export-package>

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -189,7 +189,7 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         graphQLTypeRetriever.setMethodSearchAlgorithm(methodSearchAlgorithm);
         graphQLTypeRetriever.setExtensionsHandler(extensionsHandler);
 
-        graphQLFieldWithPermissionsRetriever.setAlwaysPrettify(true);
+        graphQLFieldRetriever.setAlwaysPrettify(true);
         container = graphQLAnnotations.createContainer();
 
         specializedTypesHandler = new SpecializedTypesHandler(graphQLAnnotations, container);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -189,7 +189,7 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         graphQLTypeRetriever.setMethodSearchAlgorithm(methodSearchAlgorithm);
         graphQLTypeRetriever.setExtensionsHandler(extensionsHandler);
 
-        graphQLFieldRetriever.setAlwaysPrettify(true);
+        graphQLFieldWithPermissionsRetriever.setAlwaysPrettify(true);
         container = graphQLAnnotations.createContainer();
 
         specializedTypesHandler = new SpecializedTypesHandler(graphQLAnnotations, container);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -53,10 +53,12 @@ import graphql.annotations.processor.typeFunctions.DefaultTypeFunction;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.schema.*;
 import graphql.servlet.*;
+import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.jahia.modules.graphql.provider.dxm.node.*;
 import org.jahia.modules.graphql.provider.dxm.relay.DXConnection;
 import org.jahia.modules.graphql.provider.dxm.relay.DXRelay;
 import org.jahia.modules.graphql.provider.dxm.sdl.parsing.SDLSchemaService;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLFieldWithPermissionRetriever;
 import org.osgi.service.component.annotations.*;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -85,6 +87,7 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
     private SearchAlgorithm fieldSearchAlgorithm;
     private SearchAlgorithm methodSearchAlgorithm;
     private GraphQLExtensionsHandler extensionsHandler;
+    private DXGraphQLConfig dxGraphQLConfig;
 
     private ProcessingElementsContainer container;
 
@@ -168,12 +171,20 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         this.extensionsProviders.remove(provider);
     }
 
+    @Reference
+    public void setDxGraphQLConfig(DXGraphQLConfig dxGraphQLConfig) {
+        this.dxGraphQLConfig = dxGraphQLConfig;
+    }
+
     @Activate
     public void activate() {
         instance = this;
+
+        GraphQLFieldWithPermissionRetriever graphQLFieldWithPermissionsRetriever = new GraphQLFieldWithPermissionRetriever(dxGraphQLConfig, graphQLFieldRetriever);
+
         graphQLTypeRetriever.setGraphQLObjectInfoRetriever(graphQLObjectInfoRetriever);
         graphQLTypeRetriever.setGraphQLInterfaceRetriever(graphQLInterfaceRetriever);
-        graphQLTypeRetriever.setGraphQLFieldRetriever(graphQLFieldRetriever);
+        graphQLTypeRetriever.setGraphQLFieldRetriever(graphQLFieldWithPermissionsRetriever);
         graphQLTypeRetriever.setFieldSearchAlgorithm(fieldSearchAlgorithm);
         graphQLTypeRetriever.setMethodSearchAlgorithm(methodSearchAlgorithm);
         graphQLTypeRetriever.setExtensionsHandler(extensionsHandler);
@@ -185,6 +196,7 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         ((DefaultTypeFunction) defaultTypeFunction).register(this);
 
         GraphQLExtensionsHandler extensionsHandler = graphQLAnnotations.getExtensionsHandler();
+        extensionsHandler.setFieldRetriever(graphQLFieldWithPermissionsRetriever);
 
         relay = new DXRelay();
         sdlSchemaService.setRelay(relay);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/AdminMutationExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/AdminMutationExtensions.java
@@ -43,11 +43,9 @@
  */
 package org.jahia.modules.graphql.provider.dxm.admin;
 
-import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
-import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 import javax.jcr.RepositoryException;
 
@@ -64,7 +62,9 @@ public class AdminMutationExtensions {
      */
     @GraphQLField
     @GraphQLName("admin")
+    @GraphQLNonNull
     @GraphQLDescription("Admin Mutation")
+    @GraphQLRequiresPermission(value = "jcr:read/jcr:system")
     public static GqlAdminMutation getAdmin() throws RepositoryException {
         return new GqlAdminMutation();
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/AdminQueryExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/AdminQueryExtensions.java
@@ -45,6 +45,7 @@ package org.jahia.modules.graphql.provider.dxm.admin;
 
 import graphql.annotations.annotationTypes.*;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 /**
  * A query extension that adds admin query endpoint
@@ -60,6 +61,7 @@ public class AdminQueryExtensions {
     @GraphQLName("admin")
     @GraphQLNonNull
     @GraphQLDescription("Admin Queries")
+    @GraphQLRequiresPermission(value = "jcr:read/jcr:system")
     public static GqlAdminQuery getAdmin()  {
         return new GqlAdminQuery();
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminMutation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminMutation.java
@@ -2,10 +2,7 @@ package org.jahia.modules.graphql.provider.dxm.admin;
 
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.annotationTypes.GraphQLNonNull;
-import org.jahia.bin.Jahia;
 
 /**
  * GraphQL root object for Admin related mutations.
@@ -13,11 +10,4 @@ import org.jahia.bin.Jahia;
 @GraphQLName("adminMutation")
 @GraphQLDescription("Admin mutations")
 public class GqlAdminMutation {
-    @GraphQLField
-    @GraphQLName("version")
-    @GraphQLNonNull
-    @GraphQLDescription("Stub mutation to get version of the running Jahia instance")
-    public String getProductVersion() {
-        return Jahia.getFullProductVersion();
-    }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -44,6 +44,38 @@ public class GqlAdminQuery {
     }
 
     /**
+     * Get getJahiaVersion
+     *
+     * @return GqlJahiaVersion
+     */
+    @GraphQLField
+    @GraphQLName("jahia")
+    @GraphQLDescription("Version of the running Jahia instance")
+    public GqlJahiaVersion getJahiaVersion()  {
+
+        GqlJahiaVersion gqlJahiaVersion = new GqlJahiaVersion();
+        gqlJahiaVersion.setRelease(Optional.ofNullable(JAHIA_PROJECT_VERSION).orElse(""));
+        try {
+            gqlJahiaVersion.setBuild(MethodUtils.invokeExactStaticMethod(Jahia.class, "getBuildNumber", new Object[0]).toString());
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            logger.warn("Cannot get build number");
+        }
+        gqlJahiaVersion.setSnapshot(Optional.ofNullable(JAHIA_PROJECT_VERSION).orElse("").contains("SNAPSHOT"));
+
+        //Formatting buildDate to ISO8601
+        Date date = null;
+        try {
+            date = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.ENGLISH).parse(Jahia.getBuildDate());
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(date);
+            gqlJahiaVersion.setBuildDate(ISO8601.format(calendar));
+        } catch (ParseException e) {
+            logger.warn("Exception while parsing build date",e);
+        }
+        return gqlJahiaVersion;
+    }
+
+    /**
      * Get Build Datetime
      *
      * @return String datetime in ISO8601 format

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -8,17 +8,15 @@ import org.apache.commons.beanutils.MethodUtils;
 import org.apache.jackrabbit.util.ISO8601;
 import org.jahia.api.Constants;
 import org.jahia.bin.Jahia;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 
 
 /**
@@ -51,6 +49,7 @@ public class GqlAdminQuery {
     @GraphQLField
     @GraphQLName("jahia")
     @GraphQLDescription("Version of the running Jahia instance")
+    @GraphQLRequiresPermission(value = "admin")
     public GqlJahiaVersion getJahiaVersion()  {
 
         GqlJahiaVersion gqlJahiaVersion = new GqlJahiaVersion();

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLFieldWithPermissionRetriever.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLFieldWithPermissionRetriever.java
@@ -4,10 +4,12 @@ import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
 import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 /**
@@ -34,5 +36,27 @@ public class GraphQLFieldWithPermissionRetriever extends GraphQLFieldRetriever {
             dxGraphQLConfig.getPermissions().put(key, ann.value());
         }
         return definition;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getField(Field field, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
+        GraphQLRequiresPermission ann = field.getAnnotation(GraphQLRequiresPermission.class);
+        GraphQLFieldDefinition definition = graphQLFieldRetriever.getField(field, container);
+        if (ann != null) {
+            String key = container.getProcessing().peek() + "." + definition.getName();
+            logger.debug("Adding permission : {} = {}", key, ann.value());
+            dxGraphQLConfig.getPermissions().put(key, ann.value());
+        }
+        return definition;
+    }
+
+    @Override
+    public GraphQLInputObjectField getInputField(Method method, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
+        return graphQLFieldRetriever.getInputField(method, container);
+    }
+
+    @Override
+    public GraphQLInputObjectField getInputField(Field field, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
+        return graphQLFieldRetriever.getInputField(field, container);
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLFieldWithPermissionRetriever.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLFieldWithPermissionRetriever.java
@@ -1,0 +1,38 @@
+package org.jahia.modules.graphql.provider.dxm.security;
+
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
+import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
+import graphql.schema.GraphQLFieldDefinition;
+import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * Retrieve permission associated with field and fill security configuration
+ */
+public class GraphQLFieldWithPermissionRetriever extends GraphQLFieldRetriever {
+    private static Logger logger = LoggerFactory.getLogger(GraphQLFieldWithPermissionRetriever.class);
+
+    private DXGraphQLConfig dxGraphQLConfig;
+    private GraphQLFieldRetriever graphQLFieldRetriever;
+
+    public GraphQLFieldWithPermissionRetriever(DXGraphQLConfig dxGraphQLConfig, GraphQLFieldRetriever graphQLFieldRetriever) {
+        this.dxGraphQLConfig = dxGraphQLConfig;
+        this.graphQLFieldRetriever = graphQLFieldRetriever;
+    }
+
+    @Override
+    public GraphQLFieldDefinition getField(Method method, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
+        GraphQLRequiresPermission ann = method.getAnnotation(GraphQLRequiresPermission.class);
+        GraphQLFieldDefinition definition = graphQLFieldRetriever.getField(method, container);
+        if (ann != null) {
+            String key = container.getProcessing().peek() + "." + definition.getName();
+            logger.debug("Adding permission : {} = {}", key, ann.value());
+            dxGraphQLConfig.getPermissions().put(key, ann.value());
+        }
+        return definition;
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLRequiresPermission.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLRequiresPermission.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * Add a permission check on a field
  */
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLRequiresPermission {
     String value();

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLRequiresPermission.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLRequiresPermission.java
@@ -1,0 +1,15 @@
+package org.jahia.modules.graphql.provider.dxm.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add a permission check on a field
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLRequiresPermission {
+    String value();
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
@@ -44,10 +44,12 @@
 package org.jahia.modules.graphql.provider.dxm.user;
 
 import graphql.annotations.annotationTypes.*;
+import graphql.annotations.connection.GraphQLConnection;
 import graphql.schema.DataFetchingEnvironment;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.predicate.*;
 import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedData;
+import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedDataConnectionFetcher;
 import org.jahia.modules.graphql.provider.dxm.relay.PaginationHelper;
 import org.jahia.modules.graphql.provider.dxm.site.GqlJcrSite;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
@@ -107,6 +109,10 @@ public interface GqlPrincipal {
     boolean isMemberOf(@GraphQLName("group") @GraphQLDescription("Target group") String group,
                        @GraphQLName("site") @GraphQLDescription("Site where the group is defined") String site);
 
+    @GraphQLField
+    @GraphQLNonNull
+    @GraphQLDescription("List of groups this principal belongs to")
+    @GraphQLConnection(connectionFetcher = DXPaginatedDataConnectionFetcher.class)
     DXPaginatedData<GqlGroup> getGroupMembership(@GraphQLName("site") @GraphQLDescription("Return only groups which belong to this site") String site,
                                                  @GraphQLName("fieldFilter") @GraphQLDescription("Filter by graphQL fields values") FieldFiltersInput fieldFilter,
                                                  @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUser.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUser.java
@@ -47,6 +47,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
+import graphql.annotations.connection.GraphQLConnection;
 import graphql.schema.DataFetchingEnvironment;
 import org.jahia.data.viewhelper.principal.PrincipalViewHelper;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
@@ -56,6 +57,7 @@ import org.jahia.modules.graphql.provider.dxm.predicate.FieldFiltersInput;
 import org.jahia.modules.graphql.provider.dxm.predicate.FieldGroupingInput;
 import org.jahia.modules.graphql.provider.dxm.predicate.FieldSorterInput;
 import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedData;
+import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedDataConnectionFetcher;
 import org.jahia.modules.graphql.provider.dxm.site.GqlJcrSite;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.decorator.JCRGroupNode;
@@ -118,6 +120,10 @@ public class GqlUser implements GqlPrincipal {
         return groupNode.isMember(user.getLocalPath());
     }
 
+    @GraphQLField
+    @GraphQLNonNull
+    @GraphQLDescription("List of groups this principal belongs to")
+    @GraphQLConnection(connectionFetcher = DXPaginatedDataConnectionFetcher.class)
     public DXPaginatedData<GqlGroup> getGroupMembership(@GraphQLName("site") @GraphQLDescription("Return only groups which belong to this site") String site,
                                                         @GraphQLName("fieldFilter") @GraphQLDescription("Filter by graphQL fields values") FieldFiltersInput fieldFilter,
                                                         @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserAdminExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserAdminExtension.java
@@ -44,6 +44,7 @@
 package org.jahia.modules.graphql.provider.dxm.user;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.admin.GqlAdminQuery;
 
@@ -53,6 +54,8 @@ public class UserAdminExtension {
     private UserAdminExtension() {
     }
 
+    @GraphQLField
+    @GraphQLDescription("Get the current user")
     public static GqlUserAdmin getUserAdmin() {
         return new GqlUserAdmin();
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserAdminExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserAdminExtension.java
@@ -55,7 +55,7 @@ public class UserAdminExtension {
     }
 
     @GraphQLField
-    @GraphQLDescription("Get the current user")
+    @GraphQLDescription("Get user administration endpoint")
     public static GqlUserAdmin getUserAdmin() {
         return new GqlUserAdmin();
     }

--- a/tests/cypress/integration/api/admin/user.spec.ts
+++ b/tests/cypress/integration/api/admin/user.spec.ts
@@ -1,208 +1,208 @@
-// /* eslint-disable @typescript-eslint/no-explicit-any */
-// import gql from 'graphql-tag'
-//
-// describe('Test admin user endpoint', () => {
-//     it('gets a user', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "root") {
-//                                 name
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.name).to.equal('root')
-//         })
-//     })
-//
-//     it('gets a non existing user', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "noob") {
-//                                 name
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user).to.be.null
-//         })
-//     })
-//
-//     it('gets a user name', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "bill") {
-//                                 name
-//                                 displayName
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.name).to.equal('bill')
-//             expect(response.data.admin.userAdmin.user.displayName).to.equal('Bill Galileo')
-//         })
-//     })
-//
-//     it('tests membership', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "bill") {
-//                                 yes: memberOf(group: "site-administrators", site: "digitall")
-//                                 no: memberOf(group: "site-administrators", site: "systemsite")
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.yes).to.equal(true)
-//             expect(response.data.admin.userAdmin.user.no).to.equal(false)
-//         })
-//     })
-//
-//     it('tests membership list', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "bill") {
-//                                 groupMembership {
-//                                     pageInfo {
-//                                         totalCount
-//                                     }
-//                                     nodes {
-//                                         name
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.be.greaterThan(3)
-//             expect(response.data.admin.userAdmin.user.groupMembership.nodes.map((n) => n.name)).to.contains(
-//                 'site-administrators',
-//             )
-//         })
-//     })
-//
-//     it('tests membership list for a site', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "bill") {
-//                                 groupMembership(site: "digitall") {
-//                                     pageInfo {
-//                                         totalCount
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.equal(3)
-//         })
-//     })
-//
-//     it('tests membership list with filter', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             user(userName: "bill") {
-//                                 groupMembership(
-//                                     fieldFilter: { filters: { fieldName: "site.name", value: "digitall" } }
-//                                 ) {
-//                                     pageInfo {
-//                                         totalCount
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.equal(3)
-//         })
-//     })
-//
-//     it('tests members list', () => {
-//         cy.task('apolloNode', {
-//             baseUrl: Cypress.config().baseUrl,
-//             authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
-//             query: gql`
-//                 {
-//                     admin {
-//                         userAdmin {
-//                             group(groupName: "site-administrators", site: "digitall") {
-//                                 members {
-//                                     nodes {
-//                                         name
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             `,
-//         }).then(async (response: any) => {
-//             cy.log(JSON.stringify(response))
-//             expect(response.data.admin.userAdmin).to.exist
-//             expect(response.data.admin.userAdmin.group.members.nodes.map((n) => n.name)).to.contains('bill')
-//         })
-//     })
-// })
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import gql from 'graphql-tag'
+
+describe('Test admin user endpoint', () => {
+    it('gets a user', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "root") {
+                                name
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.name).to.equal('root')
+        })
+    })
+
+    it('gets a non existing user', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "noob") {
+                                name
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user).to.be.null
+        })
+    })
+
+    it('gets a user name', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "bill") {
+                                name
+                                displayName
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.name).to.equal('bill')
+            expect(response.data.admin.userAdmin.user.displayName).to.equal('Bill Galileo')
+        })
+    })
+
+    it('tests membership', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "bill") {
+                                yes: memberOf(group: "site-administrators", site: "digitall")
+                                no: memberOf(group: "site-administrators", site: "systemsite")
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.yes).to.equal(true)
+            expect(response.data.admin.userAdmin.user.no).to.equal(false)
+        })
+    })
+
+    it('tests membership list', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "bill") {
+                                groupMembership {
+                                    pageInfo {
+                                        totalCount
+                                    }
+                                    nodes {
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.be.greaterThan(3)
+            expect(response.data.admin.userAdmin.user.groupMembership.nodes.map((n) => n.name)).to.contains(
+                'site-administrators',
+            )
+        })
+    })
+
+    it('tests membership list for a site', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "bill") {
+                                groupMembership(site: "digitall") {
+                                    pageInfo {
+                                        totalCount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.equal(3)
+        })
+    })
+
+    it('tests membership list with filter', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            user(userName: "bill") {
+                                groupMembership(
+                                    fieldFilter: { filters: { fieldName: "site.name", value: "digitall" } }
+                                ) {
+                                    pageInfo {
+                                        totalCount
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.user.groupMembership.pageInfo.totalCount).to.equal(3)
+        })
+    })
+
+    it('tests members list', () => {
+        cy.task('apolloNode', {
+            baseUrl: Cypress.config().baseUrl,
+            authMethod: { username: 'root', password: Cypress.env('SUPER_USER_PASSWORD') },
+            query: gql`
+                {
+                    admin {
+                        userAdmin {
+                            group(groupName: "site-administrators", site: "digitall") {
+                                members {
+                                    nodes {
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+        }).then(async (response: any) => {
+            cy.log(JSON.stringify(response))
+            expect(response.data.admin.userAdmin).to.exist
+            expect(response.data.admin.userAdmin.group.members.nodes.map((n) => n.name)).to.contains('bill')
+        })
+    })
+})


### PR DESCRIPTION

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16000

## Description

Allow to use @GraphQLRequiresPermission on any gql field, to specify which permission to check , instead of filling a cfg file. Can also specify target node by adding the path after the permission name.
Restored "query/admin/jahia" field, restricted to server administrators only. query/admin and mutation/admin are visible to all privileged users.


