### PR TITLE
BACKLOG-16198 fix target jr path and revert the version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
           name: Copy artifacts
           command: |
             mkdir /tmp/artifacts/
-            cp /home/circleci/source/target/graphql-dxm-provider/*.jar /tmp/artifacts/
+            cp /home/circleci/source/target/checkout/graphql-dxm-provider/target/*.jar /tmp/artifacts/
       - store_artifacts:
           path: /tmp/artifacts/
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,6 +547,7 @@ workflows:
   # On code change is executed each time new code is pushed to a branch
   # Current project configuration in circleci only builds on PR + main, so effectively this is only being executed
   on-code-change:
+    unless: << pipeline.parameters.IS_RELEASE >>
     jobs:
       - jahia-modules-orb/initialize
       - jahia-modules-orb/update-signature:

--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-dxm-provider</artifactId>
     <name>Jahia GraphQL Core Provider</name>

--- a/graphql-extension-example/pom.xml
+++ b/graphql-extension-example/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-extension-example</artifactId>
     <name>Jahia GraphQL Extension example</name>

--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-test</artifactId>
     <groupId>org.jahia.test</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </parent>
     <artifactId>graphql-core-root</artifactId>
     <name>Jahia GraphQL Core Root</name>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the root project for the DX GraphQL Core integration project</description>
 


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-16198

## Description
reverted unsuccessful release of graphql-dxm-provider 2.6.0 and change the path to target folder of graphql-dxm-provider