### PR TITLE
BACKLOG-16198 update signature as circleci job failed to do so

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -74,7 +74,7 @@
         </export-package>
         <jahia.modules.importPackage>!org.jahia.modules.graphql.provider.dxm.sdl,!org.jahia.modules.graphql.provider.dxm.sdl.extension,!org.jahia.modules.graphql.provider.dxm.osgi.annotations</jahia.modules.importPackage>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFC3YySHa7rppNm6CR0wqPSL8QNghAhQ9ocWsznf9yREAxBJZBEM+LCzLwQ==</jahia-module-signature>
+        <jahia-module-signature>MCwCFBcjFkCyiSxf9LM8Zqox6+L5CrJ3AhRHAP0Tnka4B+4h2SH06EVSCh2J9w==</jahia-module-signature>
         <mockito.version>2.21.0</mockito.version>
         <powermock.version>2.0.7</powermock.version>
     </properties>


### PR DESCRIPTION
## JIRA

Update graphql-dxm-provider signature

## Description
Update the signature manually as circleci job failed due to the unique project structure
