### PR TITLE
BACKLOG-16280: Fix ClassCastException on node parent query

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/site/GqlJcrSite.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/site/GqlJcrSite.java
@@ -47,26 +47,34 @@ package org.jahia.modules.graphql.provider.dxm.site;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.api.Constants;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNodeImpl;
 import org.jahia.modules.graphql.provider.dxm.node.SpecializedType;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.decorator.JCRSiteNode;
 
+import javax.jcr.RepositoryException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 @GraphQLName("JCRSite")
 @GraphQLDescription("GraphQL representation of a site node")
-@SpecializedType("jnt:virtualsite")
+@SpecializedType(Constants.JAHIANT_VIRTUALSITE)
 public class GqlJcrSite extends GqlJcrNodeImpl implements GqlJcrNode {
 
     private JCRSiteNode siteNode;
 
-    public GqlJcrSite(JCRNodeWrapper node) {
+    public GqlJcrSite(JCRNodeWrapper node) throws RepositoryException {
         super(node);
-        this.siteNode = (JCRSiteNode) node;
+
+        if (node instanceof JCRSiteNode) {
+            this.siteNode = (JCRSiteNode) node;
+        } else if (node.isNodeType(Constants.JAHIANT_VIRTUALSITE)) {
+            // Workaround when site node is instanceof JCRNodeWrapperImpl
+            this.siteNode = node.getResolveSite();
+        }
     }
 
     @GraphQLField


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16280

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Getting a `ClassCastException` when querying a node parent in nodeByPath > descendants. When executing the following query for example with digitall:

```
{
  jcr {
    nodeByPath(path:"/sites/digitall/") {
      path
      descendants(
        typesFilter: {types: ["jnt:page"]}
      ) {
        nodes {
          path
          parent {
            path
          }
        }
      }
    }
  }
}
```

It gives this result where parent returns null:

```{
  "data": {
    "jcr": {
      "nodeByPath": {
        "path": "/sites/digitall",
        "descendants": {
          "nodes": [
            {
              "path": "/sites/digitall/home",
              "parent": null
            }
[...]
```

And throws this error: `java.lang.ClassCastException: org.jahia.services.content.JCRNodeWrapperImpl cannot be cast to org.jahia.services.content.decorator.JCRSiteNode`

This is because when `node.getParent()` is called on `/sites/digitall/home` [here](https://github.com/Jahia/graphql-core/blob/21419f3fd3a2de79a2d1f1a9798fa6afb032b1e9/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java#L189), it returns `JCRNodeWrapperImpl` class instead of `JCRSiteNode`. This then causes a `ClassCastException` when trying to create `GqlJcrSite` instance [here](https://github.com/Jahia/graphql-core/blob/master/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/site/GqlJcrSite.java#L69)

Added an extra check on the constructor to use `getResolvedSite()` in order to get `JCRSiteNode` instance instead of the `JCRNodeWrapperImpl` instance of the site.