### PR TITLE
BACKLOG-16333: handle the cases when context is not a servlet context

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -70,6 +70,7 @@
             org.jahia.modules.graphql.provider.dxm.sdl,
             org.jahia.modules.graphql.provider.dxm.security,
             org.jahia.modules.graphql.provider.dxm.user,
+            org.jahia.modules.graphql.provider.dxm.util,
             org.jahia.modules.graphql.provider.dxm.osgi.annotations
         </export-package>
         <jahia.modules.importPackage>!org.jahia.modules.graphql.provider.dxm.sdl,!org.jahia.modules.graphql.provider.dxm.sdl.extension,!org.jahia.modules.graphql.provider.dxm.osgi.annotations</jahia.modules.importPackage>

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
@@ -48,10 +48,10 @@ import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.schema.DataFetcher;
-import graphql.kickstart.servlet.context.GraphQLServletContext;
 import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.jahia.modules.graphql.provider.dxm.osgi.OSGIServiceInjectorDataFetcher;
 import org.jahia.modules.graphql.provider.dxm.security.GqlJcrPermissionDataFetcher;
+import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -85,7 +85,7 @@ public class JCRInstrumentation extends SimpleInstrumentation {
     public ExecutionContext instrumentExecutionContext(ExecutionContext executionContext, InstrumentationExecutionParameters parameters) {
 
         executionContext = super.instrumentExecutionContext(executionContext, parameters);
-        HttpServletRequest servletRequest = ((GraphQLServletContext) executionContext.getContext()).getHttpServletRequest();
+        HttpServletRequest servletRequest = ContextUtil.getHttpServletRequest(executionContext.getContext());
 
         // Null only in the case with integration tests.
         if (servletRequest != null) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FieldEvaluator.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FieldEvaluator.java
@@ -47,12 +47,12 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import graphql.TypeResolutionEnvironment;
 import graphql.execution.*;
-import graphql.kickstart.servlet.context.GraphQLServletContext;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
 import graphql.language.SelectionSet;
 import graphql.schema.*;
 import org.jahia.modules.graphql.provider.dxm.osgi.OSGIServiceInjectorDataFetcher;
+import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -170,16 +170,14 @@ public class FieldEvaluator {
     }
 
     private static Map<String, Object> getVariables(DataFetchingEnvironment environment) {
-        GraphQLServletContext context = environment.getContext();
-        HttpServletRequest request = context.getHttpServletRequest();
+        HttpServletRequest request = ContextUtil.getHttpServletRequest(environment.getContext());
         return (request != null) ?
                 (Map<String, Object>) request.getAttribute(GRAPHQL_VARIABLES) :
                 new LinkedHashMap<>();
     }
 
     private static Map<String, FragmentDefinition> getFragmentDefinitions(DataFetchingEnvironment environment) {
-        GraphQLServletContext context = environment.getContext();
-        HttpServletRequest request = context.getHttpServletRequest();
+        HttpServletRequest request = ContextUtil.getHttpServletRequest(environment.getContext());
         return (request != null) ?
                 (Map<String, FragmentDefinition>) request.getAttribute(FRAGMENTS_BY_NAME) :
                 new LinkedHashMap<>();

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
@@ -52,6 +52,7 @@ import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.node.NodeHelper;
 import org.jahia.modules.graphql.provider.dxm.node.SpecializedTypesHandler;
+import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.jahia.services.SpringContextSingleton;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -88,8 +89,9 @@ public class RenderNodeExtensions {
     @GraphQLDescription("Returns the first parent of the current node that can be displayed in full page. If no matching node is found, null is returned.")
     public GqlJcrNode getDisplayableNode(DataFetchingEnvironment environment) {
         GraphQLServletContext gqlContext = environment.getContext();
-        HttpServletRequest httpServletRequest = gqlContext.getHttpServletRequest();
-        HttpServletResponse httpServletResponse = gqlContext.getHttpServletResponse();
+
+        HttpServletRequest httpServletRequest = ContextUtil.getHttpServletRequest(environment.getContext());
+        HttpServletResponse httpServletResponse = ContextUtil.getHttpServletResponse(environment.getContext());
 
         if (httpServletRequest == null || httpServletResponse == null) {
             return null;
@@ -159,9 +161,8 @@ public class RenderNodeExtensions {
                 }
             }
 
-            GraphQLServletContext gqlContext = environment.getContext();
-            HttpServletRequest request = gqlContext.getHttpServletRequest();
-            HttpServletResponse response = gqlContext.getHttpServletResponse();
+            HttpServletRequest request = ContextUtil.getHttpServletRequest(environment.getContext());
+            HttpServletResponse response = ContextUtil.getHttpServletResponse(environment.getContext());
             if (request == null || response == null) {
                 throw new RuntimeException("No HttpRequest or HttpResponse");
             }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/ContextUtil.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/ContextUtil.java
@@ -41,35 +41,44 @@
  *     If you are unsure which license is appropriate for your use,
  *     please contact the sales department at sales@jahia.com.
  */
-package org.jahia.modules.graphql.provider.dxm.security;
+package org.jahia.modules.graphql.provider.dxm.util;
 
-import graphql.schema.DataFetchingEnvironment;
-import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
-import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
-import org.jahia.modules.securityfilter.PermissionService;
-import org.jahia.osgi.BundleUtils;
-import org.jahia.services.content.JCRNodeWrapper;
+import graphql.kickstart.servlet.context.GraphQLServletContext;
 
-import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-public class PermissionHelper {
+/**
+ * Simple utility class to
+ */
+public class ContextUtil {
 
-    private PermissionHelper() {
+    private ContextUtil() {
     }
 
-    public static boolean hasPermission(JCRNodeWrapper node, DataFetchingEnvironment environment) {
-        if (ContextUtil.getHttpServletRequest(environment.getContext()) != null) {
-            PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
-            if (permissionService == null) {
-                throw new DataFetchingException("Could not find permission service to validate security access. Blocking access to data.");
-            }
-            try {
-                return permissionService.hasPermission("graphql." + environment.getParentType().getName() + "." + environment.getFieldDefinition().getName(), node);
-            } catch (RepositoryException e) {
-                throw new DataFetchingException(e);
-            }
-        } else {
-            return true;
+    /**
+     * Get request if http context
+     * @param context context
+     * @return response
+     */
+    public static HttpServletRequest getHttpServletRequest(Object context) {
+        if (context instanceof GraphQLServletContext) {
+            return ((GraphQLServletContext) context).getHttpServletRequest();
         }
+
+        return null;
+    }
+
+    /**
+     * Get response if http context
+     * @param context context
+     * @return response
+     */
+    public static HttpServletResponse getHttpServletResponse(Object context) {
+        if (context instanceof GraphQLServletContext) {
+            return ((GraphQLServletContext) context).getHttpServletResponse();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16333

## Description

Previous version was using Optional in context to see if a request/response was present. Now, if servlet is called without request/response, context is a different object type. 
