### PR TITLE
TECH-210: Fix graphql file mutation test

### DIFF
--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLTestSupport.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLTestSupport.java
@@ -43,25 +43,37 @@
  */
 package org.jahia.test.graphql;
 
+import graphql.kickstart.execution.context.GraphQLContext;
 import graphql.kickstart.servlet.OsgiGraphQLHttpServlet;
-import org.apache.commons.fileupload.FileItem;
+import graphql.kickstart.servlet.context.DefaultGraphQLServletContext;
+import graphql.kickstart.servlet.context.GraphQLServletContext;
+import graphql.kickstart.servlet.context.GraphQLServletContextBuilder;
+import org.apache.commons.lang3.ArrayUtils;
 import org.jahia.api.Constants;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRTemplate;
 import org.jahia.test.JahiaTestCase;
+import org.jahia.test.graphql.context.CustomGraphQLServletContext;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import javax.websocket.Session;
+import javax.websocket.server.HandshakeRequest;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
@@ -99,11 +111,46 @@ public class GraphQLTestSupport extends JahiaTestCase {
     }
 
     protected static JSONObject executeQuery(String query) throws JSONException {
-        MockHttpServletRequest req = new MockHttpServletRequest("POST", "http://localhost:8080/modules/graphql");
+        return executeQuery(query, new MockHttpServletRequest());
+    }
+
+    protected static JSONObject executeQueryWithFiles(String query, String fileName, Map<String, List<Part>> files) throws JSONException {
+        try {
+            servlet.setContextProvider(getCustomContextProvider(files));
+            return executeQuery(query);
+        } finally {
+            servlet.unsetContextProvider(null);
+        }
+    }
+
+    /*
+     * Creating a multipart request with a file attachment WIP
+     * https://stackoverflow.com/a/30541653
+     */
+    private MockMultipartHttpServletRequest buildMultipartRequest(String fileName) {
+        byte[] data = "test text".getBytes();
+        final String boundary = "myBoundary";
+        MockMultipartFile file = new MockMultipartFile("test-binary", fileName, MediaType.TEXT_PLAIN_VALUE, data);
+        MockMultipartHttpServletRequest req = new MockMultipartHttpServletRequest();
+        req.addFile(file);
+        req.setContentType("multipart/form-data; boundary=" + boundary);
+        req.setContent(createFileContent(data, boundary, MediaType.TEXT_PLAIN_VALUE, fileName));
+        return req;
+    }
+
+    private static byte[] createFileContent(byte[] data, String boundary, String contentType, String fileName) {
+        String start = "--" + boundary + "\r\n Content-Disposition: form-data; name=\"file\"; filename=\""+fileName+"\"\r\n"
+                + "Content-type: "+contentType+"\r\n\r\n";;
+        String end = "\r\n--" + boundary + "--";
+        return ArrayUtils.addAll(start.getBytes(), ArrayUtils.addAll(data, end.getBytes()));
+    }
+
+    protected static JSONObject executeQuery(String query, MockHttpServletRequest req) throws JSONException {
+        req.setMethod("POST");
+        req.setRequestURI("http://localhost:8080/modules/graphql");
         req.addHeader("Origin", "http://localhost:8080");
 
         MockHttpServletResponse res = new MockHttpServletResponse();
-
         Object service = BundleUtils.getOsgiService("org.jahia.modules.securityfilter.PermissionService");
         if (service != null) {
             try {
@@ -142,19 +189,16 @@ public class GraphQLTestSupport extends JahiaTestCase {
         return new JSONObject(result);
     }
 
-    protected static JSONObject executeQueryWithFiles(String query, Map<String, List<FileItem>> files) throws JSONException {
-//        FIXME: uncomment file upload test for now as we have issue with migrating context creation for graphql-servlet 9.2.1
-//        try {
-//            servlet.setContextProvider((req, resp) -> {
-//                GraphQLContext context = new GraphQLContext(req,resp);
-//                context.setFiles(Optional.of(files));
-//                return context;
-//            });
-//            return executeQuery(query);
-//        } finally {
-//            servlet.unsetContextProvider(null);
-//        }
-        return null;
+    private static GraphQLServletContextBuilder getCustomContextProvider(Map<String,List<Part>> files) {
+        return new GraphQLServletContextBuilder() {
+            @Override public GraphQLContext build(HttpServletRequest request, HttpServletResponse response) {
+                GraphQLServletContext context = DefaultGraphQLServletContext
+                        .createServletContext().with(request).with(response).build();
+                return new CustomGraphQLServletContext(context, files);
+            }
+            @Override public GraphQLContext build(Session session, HandshakeRequest handshakeRequest) { return null; }
+            @Override public GraphQLContext build() { return null; }
+        };
     }
 
     protected static Map<String, JSONObject> toItemByKeyMap(String key, JSONArray items) throws JSONException {

--- a/graphql-test/src/main/java/org/jahia/test/graphql/context/CustomGraphQLServletContext.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/context/CustomGraphQLServletContext.java
@@ -1,0 +1,76 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.test.graphql.context;
+
+import graphql.kickstart.servlet.context.GraphQLServletContext;
+import org.dataloader.DataLoaderRegistry;
+
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Custom GraphQL context to inject file upload for testing
+ */
+public class CustomGraphQLServletContext implements GraphQLServletContext {
+
+    GraphQLServletContext context;
+    Map<String, List<Part>> files;
+
+    public CustomGraphQLServletContext(GraphQLServletContext context, Map<String, List<Part>> files) {
+        this.context = context;
+        this.files = files;
+    }
+
+    @Override public List<Part> getFileParts() {
+        for (String s: files.keySet()) {
+            return files.get(s);
+        }
+        return null;
+    }
+
+    @Override public Map<String, List<Part>> getParts() {
+        return files;
+    }
+
+    @Override public HttpServletRequest getHttpServletRequest() {
+        return context.getHttpServletRequest();
+    }
+
+    @Override public HttpServletResponse getHttpServletResponse() {
+        return context.getHttpServletResponse();
+    }
+
+    @Override public Optional<Subject> getSubject() {
+        return context.getSubject();
+    }
+
+    @Override public Optional<DataLoaderRegistry> getDataLoaderRegistry() {
+        return context.getDataLoaderRegistry();
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-210

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix GraphQL mutation upload test

I've explored multiple ways of fixing the tests. One is the current way of injecting the file to test into the GraphQL context. Fixed by creating a custom GraphQL context and ContextBuilder to be able to inject into the service, and wrap old FileItem into a javax.http.servlet.Part instance.

I've also tried another route of creating a Multipart request that attaches file contents but had some issue with having both file content and the query request (it wasn't obvious how both are attached and probably needs further exploration later). I've kept the code as separate functions but not used just in case we want to continue exploring that path later on.
