### PR TITLE
BACKLOG-16328: Fixed error handling, add errorType in return

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaDataFetchingExceptionHandler.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaDataFetchingExceptionHandler.java
@@ -63,17 +63,6 @@ import java.util.Collections;
 public class JahiaDataFetchingExceptionHandler implements DataFetcherExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(JahiaDataFetchingExceptionHandler.class);
 
-    public void accept(DataFetcherExceptionHandlerParameters handlerParameters) {
-        Throwable exception = handlerParameters.getException();
-
-        ExecutionPath path = handlerParameters.getPath();
-        GraphQLError error = transformException(exception, path, handlerParameters.getField().getSingleField().getSourceLocation());
-
-        if (!(error instanceof DXGraphQLError)) {
-            log.warn(error.getMessage(), exception);
-        }
-    }
-
     public static GraphQLError transformException(Throwable exception, ExecutionPath path, SourceLocation sourceLocation) {
         // Unwrap exception from MethodDataFetcher
         if (exception instanceof RuntimeException && exception.getCause() instanceof InvocationTargetException) {
@@ -87,8 +76,8 @@ public class JahiaDataFetchingExceptionHandler implements DataFetcherExceptionHa
         }
     }
 
-    @Override public DataFetcherExceptionHandlerResult onException(
-            DataFetcherExceptionHandlerParameters handlerParameters) {
+    @Override
+    public DataFetcherExceptionHandlerResult onException(DataFetcherExceptionHandlerParameters handlerParameters) {
         Throwable exception = handlerParameters.getException();
 
         ExecutionPath path = handlerParameters.getPath();


### PR DESCRIPTION
Servlet is now using a dedicated method to serialize the error, instead of jackson.
A new ErrorClassification has been added and is more fexible than the previous error type, which allows us to directly return the value we want in `getErrorType` and get rid of `getRealErrorType`
