### PR TITLE
TECH-268: Add annotation to create AsyncDataFetcher

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>security-filter</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLAsync.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GraphQLAsync.java
@@ -1,0 +1,14 @@
+package org.jahia.modules.graphql.provider.dxm.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add a permission check on a field
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLAsync {
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/JahiaGraphQLFieldRetriever.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/JahiaGraphQLFieldRetriever.java
@@ -3,56 +3,74 @@ package org.jahia.modules.graphql.provider.dxm.security;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
+import graphql.schema.AsyncDataFetcher;
+import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
 import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
 
+import static graphql.schema.FieldCoordinates.coordinates;
 /**
  * Retrieve permission associated with field and fill security configuration
  */
-public class GraphQLFieldWithPermissionRetriever extends GraphQLFieldRetriever {
-    private static Logger logger = LoggerFactory.getLogger(GraphQLFieldWithPermissionRetriever.class);
+public class JahiaGraphQLFieldRetriever extends GraphQLFieldRetriever {
+    private static Logger logger = LoggerFactory.getLogger(JahiaGraphQLFieldRetriever.class);
 
     private DXGraphQLConfig dxGraphQLConfig;
     private GraphQLFieldRetriever graphQLFieldRetriever;
 
-    public GraphQLFieldWithPermissionRetriever(DXGraphQLConfig dxGraphQLConfig, GraphQLFieldRetriever graphQLFieldRetriever) {
+    private Executor executor;
+
+    public JahiaGraphQLFieldRetriever(DXGraphQLConfig dxGraphQLConfig, GraphQLFieldRetriever graphQLFieldRetriever, Executor executor) {
         this.dxGraphQLConfig = dxGraphQLConfig;
         this.graphQLFieldRetriever = graphQLFieldRetriever;
+        this.executor = executor;
     }
 
     @Override
     public GraphQLFieldDefinition getField(String parentName, Method method, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
-        GraphQLRequiresPermission ann = method.getAnnotation(GraphQLRequiresPermission.class);
-
         // TODO: This is a hack (not related to permissions) to fix the way the OutputObjectBuilder is handling the extensions on interfaces.
         // The parentname is the name of the interface, where it should be the name of the type.
         // This result in fieldRetriever not correctly registering the dataFetcher in the codeRegistry.
         String realParentName = container.getProcessing().peek();
         GraphQLFieldDefinition definition = graphQLFieldRetriever.getField(realParentName, method, container);
-        if (ann != null) {
-            String key = container.getProcessing().peek() + "." + definition.getName();
-            logger.debug("Adding permission : {} = {}", key, ann.value());
-            dxGraphQLConfig.getPermissions().put(key, ann.value());
-        }
+
+        wrap(method, parentName, container, definition);
+
         return definition;
     }
 
     @Override
     public GraphQLFieldDefinition getField(String parentName, Field field, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
-        GraphQLRequiresPermission ann = field.getAnnotation(GraphQLRequiresPermission.class);
         GraphQLFieldDefinition definition = graphQLFieldRetriever.getField(parentName, field, container);
+
+        wrap(field, parentName, container, definition);
+
+        return definition;
+    }
+
+    private void wrap(AnnotatedElement element, String parentName, ProcessingElementsContainer container, GraphQLFieldDefinition definition) {
+        GraphQLRequiresPermission ann = element.getAnnotation(GraphQLRequiresPermission.class);
         if (ann != null) {
             String key = container.getProcessing().peek() + "." + definition.getName();
             logger.debug("Adding permission : {} = {}", key, ann.value());
             dxGraphQLConfig.getPermissions().put(key, ann.value());
         }
-        return definition;
+
+        GraphQLAsync async = element.getAnnotation(GraphQLAsync.class);
+        if (async != null) {
+            DataFetcher<?> dataFetcher = container.getCodeRegistryBuilder().getDataFetcher(coordinates(parentName, definition.getName()), definition);
+            AsyncDataFetcher<?> asyncDataFetcher = AsyncDataFetcher.async(dataFetcher, executor);
+            logger.debug("Creating async DataFetcher : {} {}", parentName, definition.getName());
+            container.getCodeRegistryBuilder().dataFetcher(coordinates(parentName, definition.getName()), asyncDataFetcher);
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-268

## Description

New @GraphQLAsync annotation will transform the datafetcher into async, using custom executor. Executor handle user/scopes so that permissions can be correctly checked.
OSGI injector fixed to work with async datafetcher.
