### PR TITLE
TECH-210: Add support for multiple GraphQL errors; Fix tests

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/AggregateDataFetchingException.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/AggregateDataFetchingException.java
@@ -1,0 +1,43 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.graphql.provider.dxm;
+
+import java.util.List;
+
+/**
+ * Exception for propagating multiple DataFetchingException errors
+ */
+public class AggregateDataFetchingException extends DataFetchingException {
+
+    private List<DataFetchingException> errors;
+
+    public AggregateDataFetchingException(List<DataFetchingException> errors) {
+        super(AggregateDataFetchingException.class.getName());
+        this.errors = errors;
+    }
+
+    public List<DataFetchingException> getErrors() {
+        return errors;
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrQuery.java
@@ -176,13 +176,19 @@ public class GqlJcrQuery {
     @GraphQLDescription("Get GraphQL representations of multiple nodes by their UUIDs")
     public Collection<GqlJcrNode> getNodesById(@GraphQLName("uuids") @GraphQLNonNull @GraphQLDescription("The UUIDs of the nodes") Collection<@GraphQLNonNull String> uuids, DataFetchingEnvironment environment) {
         List<GqlJcrNode> nodes = new ArrayList<>(uuids.size());
+        List<DataFetchingException> errors = new ArrayList<>();
         for (String uuid : uuids) {
             try {
                 nodes.add(getGqlNodeById(uuid));
-            } catch (RepositoryException e) {
-                throw new DataFetchingException(e);
+            } catch (RepositoryException re) {
+                errors.add(new DataFetchingException(re));
             }
         }
+
+        if (!errors.isEmpty()) {
+            throw new AggregateDataFetchingException(errors);
+        }
+
         return nodes;
     }
 
@@ -199,13 +205,19 @@ public class GqlJcrQuery {
     @GraphQLDescription("Get GraphQL representations of multiple nodes by their paths")
     public Collection<GqlJcrNode> getNodesByPath(@GraphQLName("paths") @GraphQLNonNull @GraphQLDescription("The paths of the nodes") Collection<@GraphQLNonNull String> paths, DataFetchingEnvironment environment) {
         List<GqlJcrNode> nodes = new ArrayList<>(paths.size());
+        List<DataFetchingException> errors = new ArrayList<>();
         for (String path : paths) {
             try {
                 nodes.add(getGqlNodeByPath(path));
-            } catch (RepositoryException e) {
-                throw new DataFetchingException(e);
+            } catch (RepositoryException re) {
+                errors.add(new DataFetchingException(re));
             }
         }
+
+        if (!errors.isEmpty()) {
+            throw new AggregateDataFetchingException(errors);
+        }
+
         return nodes;
     }
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/upload/UploadHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/upload/UploadHelper.java
@@ -47,7 +47,6 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.kickstart.servlet.context.GraphQLServletContext;
 import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrWrongInputException;
-import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.jahia.settings.SettingsBean;
 
 import javax.servlet.http.Part;
@@ -72,7 +71,7 @@ public class UploadHelper {
             return false;
         }
 
-        Part part = UploadHelper.getPartForFilename(context, name);
+        Part part = UploadHelper.getPartForName(context, name);
         if (part == null) {
             return false;
         }
@@ -110,7 +109,7 @@ public class UploadHelper {
             throw new GqlJcrWrongInputException("Must use multipart request");
         }
 
-        Part part = getPartForFilename(context, name);
+        Part part = getPartForName(context, name);
         if (part == null) {
             throw new GqlJcrWrongInputException("Must send file as multipart request for " + name);
         }
@@ -118,16 +117,13 @@ public class UploadHelper {
     }
 
     /**
-     *
-     * @param context
-     * @param filename
-     * @return file upload Part that matches filename, or null if no Part exists or
-     * if there are more than one part that has the same filename
+     * @return File upload Part that matches name from context file parts,
+     * or null if no Part exists or if there are more than one part that has the same filename
      */
-    private static Part getPartForFilename(GraphQLServletContext context, String filename) {
+    private static Part getPartForName(GraphQLServletContext context, String name) {
         List<Part> parts = context.getFileParts()
                 .stream()
-                .filter(part -> filename.equals(part.getName()))
+                .filter(part -> name.equals(part.getName()))
                 .collect(Collectors.toList());
 
         return (parts.isEmpty() || parts.size() > 1) ?

--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLNodeMutationsTest.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLNodeMutationsTest.java
@@ -43,8 +43,6 @@
  */
 package org.jahia.test.graphql;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.disk.DiskFileItem;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jahia.api.Constants;
@@ -52,6 +50,7 @@ import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNodeMutation.ReorderedC
 import org.jahia.services.content.*;
 import org.jahia.settings.readonlymode.ReadOnlyModeController;
 import org.jahia.settings.readonlymode.ReadOnlyModeController.ReadOnlyModeStatus;
+import org.jahia.test.graphql.utils.TestFileUtils;
 import org.jahia.utils.EncryptionUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -61,8 +60,6 @@ import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.servlet.http.Part;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -1061,63 +1058,19 @@ public class GraphQLNodeMutationsTest extends GraphQLTestSupport {
         });
     }
 
-
-    public static Part toPart(FileItem fileItem) {
-        return new Part() {
-            @Override public InputStream getInputStream() throws IOException {
-                return fileItem.getInputStream();
-            }
-
-            @Override public String getContentType() {
-                return fileItem.getContentType();
-            }
-
-            @Override public String getName() {
-                return fileItem.getName();
-            }
-
-            @Override public long getSize() {
-                return fileItem.getSize();
-            }
-
-            @Override public void write(String s) throws IOException {
-                // auto-generated; do nothing
-            }
-
-            @Override public void delete() throws IOException {
-                fileItem.delete();
-            }
-
-            @Override public String getHeader(String s) {
-                return fileItem.getHeaders().getHeader(s);
-            }
-
-            @Override public Collection<String> getHeaders(String s) {
-                return null;
-            }
-
-            @Override public Collection<String> getHeaderNames() {
-                return null;
-            }
-        };
-    }
-
     @Test
-    public void propertyBinaryValue() throws Exception{
-        Map<String,List<Part>> files = new HashMap<>();
-        String fileName = "file.txt";
-        DiskFileItem diskFileItem = new DiskFileItem("", "text/plain", false, fileName, 100, null);
-        OutputStream outputStream = diskFileItem.getOutputStream();
-        IOUtils.write("test text", outputStream);
-        outputStream.close();
-        files.put("test-binary", Collections.singletonList(toPart(diskFileItem)));
+    public void propertyBinaryValue() throws Exception {
+        String fieldName = "test-binary";
+        String fileName = "filename1.txt";
+        String fileContent = "test text content";
+        Part uploadFile = TestFileUtils.getFilePart(fieldName, fileName, fileContent);
 
         JSONObject result = executeQueryWithFiles("mutation {\n" +
                 "  jcr {\n" +
-                "    addNode(parentPathOrId:\"/testFolder\", name:\""+ fileName + "\", primaryNodeType:\"jnt:file\") {\n" +
+                "    addNode(parentPathOrId:\"/testFolder\", name:\"" + fileName + "\", primaryNodeType:\"jnt:file\") {\n" +
                 "      addChild(name:\"jcr:content\", primaryNodeType:\"nt:resource\") {\n" +
                 "        setData:mutateProperty(name:\"jcr:data\") {\n" +
-                "          setValue(value:\"test-binary\")\n" +
+                "          setValue(value:\""  + fieldName + "\")\n" +
                 "        }\n" +
                 "        setMimeType:mutateProperty(name:\"jcr:mimeType\") {\n" +
                 "          setValue(value:\"text/plain\")\n" +
@@ -1130,28 +1083,57 @@ public class GraphQLNodeMutationsTest extends GraphQLTestSupport {
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n", fileName, files);
+                "}\n", Collections.singletonList(uploadFile));
 
-        String value = result.getJSONObject("data").getJSONObject("jcr").getJSONObject("addNode").getJSONObject("addChild").getJSONObject("node")
+        String value = result.getJSONObject("data").getJSONObject("jcr")
+                .getJSONObject("addNode").getJSONObject("addChild").getJSONObject("node")
                 .getJSONObject("property").getString("value");
+        assertEquals(fileContent, value);
 
-        assertEquals("test text", value);
+        inJcr(session -> {
+            assertTrue(session.nodeExists("/testFolder/" + fileName));
+            JCRNodeWrapper fileNode = session.getNode("/testFolder/" + fileName);
+            assertTrue(fileNode.isNodeType(Constants.JAHIANT_FILE));
+            assertEquals("text/plain", fileNode.getFileContent().getContentType());
 
-        // test binary property by providing its value as string
-        executeQuery("mutation {\n" +
+            try {
+                assertEquals(fileContent, IOUtils.toString(fileNode.getFileContent().downloadFile()));
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+            return null;
+        });
+    }
+
+    /** Test binary property by providing its value as string */
+    @Test
+    public void propertyBinaryValueAsString() throws Exception {
+        String fileContent = "my text binary value";
+        JSONObject result = executeQueryWithFiles("mutation {\n" +
                 "  jcr {\n" +
                 "    addNode(parentPathOrId:\"/testFolder\", name:\"file2.txt\", primaryNodeType:\"jnt:file\") {\n" +
+                "      uuid\n" +
                 "      addChild(name:\"jcr:content\", primaryNodeType:\"nt:resource\") {\n" +
                 "        setData:mutateProperty(name:\"jcr:data\") {\n" +
-                "          setValue(value:\"my text binary value\")\n" +
+                "          setValue(value:\"" + fileContent + "\")\n" +
                 "        }\n" +
                 "        setMimeType:mutateProperty(name:\"jcr:mimeType\") {\n" +
                 "          setValue(value:\"text/plain\")\n" +
                 "        }\n" +
+                "        node {\n" +
+                "          property(name:\"jcr:data\") {\n" +
+                "            value\n" +
+                "          }\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
-                "}\n");
+                "}\n", new ArrayList<>()); // empty files
+
+        String value = result.getJSONObject("data").getJSONObject("jcr")
+                .getJSONObject("addNode").getJSONObject("addChild").getJSONObject("node")
+                .getJSONObject("property").getString("value");
+        assertEquals(fileContent, value);
 
         inJcr(session -> {
             assertTrue(session.nodeExists("/testFolder/file2.txt"));
@@ -1160,7 +1142,7 @@ public class GraphQLNodeMutationsTest extends GraphQLTestSupport {
             assertEquals("text/plain", fileNode.getFileContent().getContentType());
 
             try {
-                assertEquals("my text binary value", IOUtils.toString(fileNode.getFileContent().downloadFile()));
+                assertEquals(fileContent, IOUtils.toString(fileNode.getFileContent().downloadFile()));
             } catch (IOException e) {
                 fail(e.getMessage());
             }

--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
@@ -73,7 +73,7 @@ public class GraphQLSchedulerTest extends GraphQLTestSupport {
         schedulerService = ServicesRegistry.getInstance().getSchedulerService();
     }
 
-    @Test
+    /** TODO disabling for now until we implement gql subscription */
     public void testJobSubscription() throws Exception {
 
         NettyHttpClientBuilder nettyHttpClientBuilder = new NettyHttpClientBuilder();

--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLTestSupport.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLTestSupport.java
@@ -114,7 +114,7 @@ public class GraphQLTestSupport extends JahiaTestCase {
         return executeQuery(query, new MockHttpServletRequest());
     }
 
-    protected static JSONObject executeQueryWithFiles(String query, String fileName, Map<String, List<Part>> files) throws JSONException {
+    protected static JSONObject executeQueryWithFiles(String query, List<Part> files) throws JSONException {
         try {
             servlet.setContextProvider(getCustomContextProvider(files));
             return executeQuery(query);
@@ -135,6 +135,7 @@ public class GraphQLTestSupport extends JahiaTestCase {
         req.addFile(file);
         req.setContentType("multipart/form-data; boundary=" + boundary);
         req.setContent(createFileContent(data, boundary, MediaType.TEXT_PLAIN_VALUE, fileName));
+
         return req;
     }
 
@@ -189,7 +190,7 @@ public class GraphQLTestSupport extends JahiaTestCase {
         return new JSONObject(result);
     }
 
-    private static GraphQLServletContextBuilder getCustomContextProvider(Map<String,List<Part>> files) {
+    private static GraphQLServletContextBuilder getCustomContextProvider(List<Part> files) {
         return new GraphQLServletContextBuilder() {
             @Override public GraphQLContext build(HttpServletRequest request, HttpServletResponse response) {
                 GraphQLServletContext context = DefaultGraphQLServletContext

--- a/graphql-test/src/main/java/org/jahia/test/graphql/context/CustomGraphQLServletContext.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/context/CustomGraphQLServletContext.java
@@ -33,6 +33,7 @@ import javax.servlet.http.Part;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Custom GraphQL context to inject file upload for testing
@@ -40,22 +41,20 @@ import java.util.Optional;
 public class CustomGraphQLServletContext implements GraphQLServletContext {
 
     GraphQLServletContext context;
-    Map<String, List<Part>> files;
+    List<Part> files;
 
-    public CustomGraphQLServletContext(GraphQLServletContext context, Map<String, List<Part>> files) {
+    public CustomGraphQLServletContext(GraphQLServletContext context, List<Part> files) {
         this.context = context;
         this.files = files;
     }
 
     @Override public List<Part> getFileParts() {
-        for (String s: files.keySet()) {
-            return files.get(s);
-        }
-        return null;
+        return files;
     }
 
     @Override public Map<String, List<Part>> getParts() {
-        return files;
+        // based from DefaultGraphQLServletContext implementation
+        return files.stream().collect(Collectors.groupingBy(Part::getName));
     }
 
     @Override public HttpServletRequest getHttpServletRequest() {

--- a/graphql-test/src/main/java/org/jahia/test/graphql/utils/TestFileUtils.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/utils/TestFileUtils.java
@@ -1,0 +1,93 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2021 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.test.graphql.utils;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.io.IOUtils;
+
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+/**
+ * File utilities for upload tests
+ */
+public class TestFileUtils {
+
+    public static Part getFilePart(String fieldName, String fileName, String fileContent) throws IOException {
+        DiskFileItem diskFileItem = new DiskFileItem(fieldName, "text/plain",
+                false, fileName, 100, null);
+
+        OutputStream out = diskFileItem.getOutputStream();
+        IOUtils.write(fileContent.getBytes(StandardCharsets.UTF_8), out);
+        IOUtils.close(out);
+
+        return toPart(diskFileItem);
+    }
+
+    public static Part toPart(FileItem fileItem) {
+        return new Part() {
+            @Override public InputStream getInputStream() throws IOException {
+                return fileItem.getInputStream();
+            }
+
+            @Override public String getContentType() {
+                return fileItem.getContentType();
+            }
+
+            @Override public String getName() {
+                return fileItem.getFieldName();
+            }
+
+            @Override public long getSize() {
+                return fileItem.getSize();
+            }
+
+            @Override public void write(String s) throws IOException {
+                // auto-generated; do nothing
+            }
+
+            @Override public void delete() throws IOException {
+                fileItem.delete();
+            }
+
+            @Override public String getHeader(String s) {
+                return fileItem.getHeaders().getHeader(s);
+            }
+
+            @Override public Collection<String> getHeaders(String s) {
+                return null;
+            }
+
+            @Override public Collection<String> getHeaderNames() {
+                return null;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-210

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Add support for multiple GraphQL errors through DataFetchingException (not sure if there's a better solution through contexts or through graphql.execution.DataFetcherResult)
* Fix upload file tests
* Disable subscription test