### PR TITLE
TECH-328: Add authentication to subscription test

### DIFF
--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
@@ -96,6 +96,8 @@ public class GraphQLSchedulerTest extends GraphQLTestSupport {
                                 "}";
 
         // try authenticating first before connecting to websocket
+
+
         httpClient.createGet(getBaseServerURL() + Jahia.getContextPath() + "/jahia")
                 .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("root:root1234".getBytes()))
                 .addHeader("Origin", getBaseServerURL())
@@ -105,8 +107,6 @@ public class GraphQLSchedulerTest extends GraphQLTestSupport {
         WebSocketClient webSocketClient = httpClient.createWebSocket(url)
                 .idleTimeoutMillis(10000)
                 .totalRequestTimeoutMillis(10000)
-                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("root:root1234".getBytes()))
-                .addHeader("Origin", getBaseServerURL())
                 .build().build();
         webSocketClient.addListener(new MyWebSocketMessageListener(testJob, jobDatas));
         webSocketClient.connect().get();

--- a/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
+++ b/graphql-test/src/main/java/org/jahia/test/graphql/GraphQLSchedulerTest.java
@@ -95,6 +95,12 @@ public class GraphQLSchedulerTest extends GraphQLTestSupport {
                                     "}\n" +
                                 "}";
 
+        // try authenticating first before connecting to websocket
+        httpClient.createGet(getBaseServerURL() + Jahia.getContextPath() + "/jahia")
+                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("root:root1234".getBytes()))
+                .addHeader("Origin", getBaseServerURL())
+                .build().execute();
+
         String url = (getBaseServerURL() + Jahia.getContextPath() + "/modules/graphql").replaceFirst("http", "ws");
         WebSocketClient webSocketClient = httpClient.createWebSocket(url)
                 .idleTimeoutMillis(10000)


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-328

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

From failing test [here](https://rqa2.jahia.com/bamboo/browse/JT71XX-DX71MT-JOB1-1150/test/case/177496205), seems that establishing websocket connection seems to be failing because of a null session (see logs [here](https://rqa2.jahia.com/bamboo/artifact/JT71XX-DX71MT/JOB1/build-1150/Server-logs/rqa3.int.jahia.com/clustertrunk/jahia.log) and search "schedulertest") with the following error:

```
2021-09-01 14:31:38,022: INFO  [http-nio-5050-exec-8] org.jahia.test.bin.TestServlet: Executing test classes class org.jahia.test.graphql.GraphQLSchedulerTest
2021-09-01 14:31:38,456: ERROR [http-nio-5050-exec-4] org.jahia.bin.errors.ErrorLoggingFilter: java.lang.NullPointerException
java.lang.NullPointerException: null
	at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1011) ~[?:1.8.0_144]
	at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1006) ~[?:1.8.0_144]
	at org.jahia.modules.graphql.provider.dxm.OsgiGraphQLWsEndpoint$Configurator.modifyHandshake(OsgiGraphQLWsEndpoint.java:126) ~[?:?]
```
which seems to point to an invalid session. Looking around, not sure if Authorization/Authentication headers are actually supported on a websocket connection (see [this](https://stackoverflow.com/a/4361358) stackoverflow and [this](https://devcenter.heroku.com/articles/websocket-security#authentication-authorization) article.

Checking to see if authenticating first and then connecting to websocket connection might help the failing test issue.


