### PR TITLE
QA-13889: close sessions opened when creating a subscription

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaSubscriptionExecutionStrategy.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaSubscriptionExecutionStrategy.java
@@ -46,6 +46,7 @@ package org.jahia.modules.graphql.provider.dxm;
 import graphql.ExecutionResult;
 import graphql.execution.*;
 import graphql.kickstart.servlet.context.DefaultGraphQLWebSocketContext;
+import org.jahia.bin.filters.jcr.JcrSessionFilter;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.usermanager.JahiaUser;
 
@@ -66,7 +67,7 @@ public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStr
             JCRSessionFactory.getInstance().setCurrentUser((JahiaUser) httpSession.getAttribute("org.jahia.usermanager.jahiauser"));
             return super.execute(executionContext, parameters);
         } finally {
-            JCRSessionFactory.getInstance().setCurrentUser(null);
+            JcrSessionFilter.endRequest();
         }
     }
 
@@ -78,7 +79,7 @@ public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStr
             JCRSessionFactory.getInstance().setCurrentUser((JahiaUser) httpSession.getAttribute("org.jahia.usermanager.jahiauser"));
             return super.completeField(executionContext, parameters, fetchedValue);
         } finally {
-            JCRSessionFactory.getInstance().setCurrentUser(null);
+            JcrSessionFilter.endRequest();
         }
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13889

## Description

When using websocket, session stays open and keeps a potentially invalid cache, crashing request when it is reused