### PR TITLE
QA-13939 Use logger instead of e.printStackTrace()

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/FinderFetchersFactory.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/FinderFetchersFactory.java
@@ -107,8 +107,7 @@ public class FinderFetchersFactory {
                     return "Weakreference";
                 }
             } catch (NoSuchNodeTypeException e) {
-                e.printStackTrace();
-                logger.error("Node type is not found due to {}", e.getMessage());
+                logger.error("Node type is not found due to", e);
             }
         }
         return graphQLType.getFieldDefinition(definitionPropertyName).getType().getName();


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13939

## Description

Use logger instead of e.printStackTrace()
