### PR TITLE
QA-13933: Shutdown executor

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/BeanWrapper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/BeanWrapper.java
@@ -1,0 +1,95 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2020 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.modules.graphql.provider.dxm.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Wrap bean to access private fields/methods
+ */
+@SuppressWarnings("java:S3011")
+public class BeanWrapper {
+    private final Object bean;
+
+    private BeanWrapper(Object bean) {
+        this.bean = bean;
+    }
+
+    public static BeanWrapper wrap(Object bean) {
+        return new BeanWrapper(bean);
+    }
+
+    public BeanWrapper get(String property) throws ReflectiveOperationException {
+        return get(property, bean.getClass());
+    }
+
+    public BeanWrapper get(String property, Class<?> clazz) throws ReflectiveOperationException {
+        Field f = clazz.getDeclaredField(property);
+        f.setAccessible(true);
+        return new BeanWrapper(f.get(bean));
+    }
+
+    public BeanWrapper call(String method) throws ReflectiveOperationException {
+        return call(method, new Class[0], new Object[0]);
+    }
+
+    public BeanWrapper call(String method, Class<?> clazz) throws ReflectiveOperationException {
+        return call(method, clazz, new Class[0], new Object[0]);
+    }
+
+    public BeanWrapper call(String method, Class<?>[] paramTypes, Object[] params) throws ReflectiveOperationException {
+        return call(method, bean.getClass(), paramTypes, params);
+    }
+
+    public BeanWrapper call(String method, Class<?> clazz, Class<?>[] paramTypes, Object[] params) throws ReflectiveOperationException {
+        Method m = clazz.getDeclaredMethod(method, paramTypes);
+        m.setAccessible(true);
+        return new BeanWrapper(m.invoke(bean, params));
+    }
+
+    public <T> T unwrap(Class<T> target) {
+        return target.cast(bean);
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13933

## Description

This should be fixed directly in graphql-java-servlet, however in the meantime I did not see any other solution that this nice reflection sequence to shutdown the internal executor
