### PR TITLE
BACKLOG-16502: remove GraphQLFieldSorterTest

### DIFF
--- a/graphql-test/src/main/resources/META-INF/spring/mod-graphql-test.xml
+++ b/graphql-test/src/main/resources/META-INF/spring/mod-graphql-test.xml
@@ -20,7 +20,6 @@
                 <value>org.jahia.test.graphql.GraphQLWorkflowTest</value>
                 <value>org.jahia.test.graphql.GraphQLSchedulerTest</value>
                 <value>org.jahia.test.graphql.GraphQLi18nTest</value>
-                <value>org.jahia.test.graphql.GraphQLFieldSorterTest</value>
                 <value>org.jahia.test.graphql.GraphQLOrderingTest</value>
                 <value>org.jahia.test.graphql.GraphQLRenderTest</value>
                 <value>org.jahia.test.graphql.GraphQLZipMutationTest</value>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-16502

## Description

Already replaced the test with https://github.com/Jahia/graphql-core/pull/200, but missed this removal


## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
