### PR TITLE
BACKLOG-16506_remove : remove test in xml

### DIFF
--- a/graphql-test/src/main/resources/META-INF/spring/mod-graphql-test.xml
+++ b/graphql-test/src/main/resources/META-INF/spring/mod-graphql-test.xml
@@ -20,7 +20,6 @@
                 <value>org.jahia.test.graphql.GraphQLWorkflowTest</value>
                 <value>org.jahia.test.graphql.GraphQLSchedulerTest</value>
                 <value>org.jahia.test.graphql.GraphQLi18nTest</value>
-                <value>org.jahia.test.graphql.GraphQLOrderingTest</value>
                 <value>org.jahia.test.graphql.GraphQLRenderTest</value>
                 <value>org.jahia.test.graphql.GraphQLZipMutationTest</value>
                 <value>org.jahia.test.graphql.GraphQLRenderTest</value>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-16506

## Description
Removed the graphql test from the xml list.