### PR TITLE
BACKLOG-17102: Moved release runner to self-hosted

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   on-release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
     # with common Jahia dependencies. Using this prevents maven from


### PR DESCRIPTION
Some of the more complex builds require us to use our self-hosted runner to provide more CPU/RAM
