### PR TITLE
QA-14647: Don't take returned filename, which is OS path separator based

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/ZipUtils.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/util/ZipUtils.java
@@ -141,7 +141,7 @@ public class ZipUtils {
                     JCRSessionWrapper currentUserSession = JCRSessionFactory.getInstance().getCurrentUserSession(Constants.EDIT_WORKSPACE);
 
                     String filename = zipEntry.getName().replace('\\', '/');
-                    filename = validateFilename(filename);
+                    validateFilename(filename);
                     if (filename.endsWith("/")) {
                         filename = filename.substring(0, filename.length() - 1);
                     }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-14647

## Description

Don't take returned filename, which is OS path separator based

