### PR TITLE
SUP-233: Prevent npe issues with broken references

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
@@ -366,7 +366,9 @@ public class GqlJcrNodeImpl implements GqlJcrNode {
                 }
                 GqlJcrNode gqlReferencingNode = SpecializedTypesHandler.getNode(referencingNode);
                 GqlJcrProperty gqlReference = gqlReferencingNode.getProperty(name, locale, false);
-                gqlReferences.add(gqlReference);
+                if (gqlReference != null) {
+                    gqlReferences.add(gqlReference);
+                }
             }
         }
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FieldEvaluator.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/FieldEvaluator.java
@@ -185,6 +185,9 @@ public class FieldEvaluator {
      * @return The value, as returned by the DataFetcher
      */
     public Object getFieldValue(Object source, String fieldName) {
+        if (source == null) {
+            return null;
+        }
         List<String> fields = Splitter.on(FIELD_NAME_SEPARATOR).splitToList(fieldName);
         String nextField = null;
         if (fields.size() > 1) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SUP-233

## Description

Issue was originally introduced by BACKLOG-20469 (graphql 2.15.0). If a referenceInField points to a non existing property, it fills a null property. If for any reason a null property is added to the results, it crashes the filter - so we need to avoid putting null in there.
Also added a check in getFieldValue to avoid the npe if source is null.
