### PR TITLE
BACKLOG-20609: Adding more nodes to fetch system information

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlAdminQuery.java
@@ -26,6 +26,7 @@ import org.jahia.modules.graphql.provider.dxm.acl.GqlAclRole;
 import org.jahia.modules.graphql.provider.dxm.acl.service.JahiaAclService;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.settings.SettingsBean;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
@@ -84,5 +85,19 @@ public class GqlAdminQuery {
         return Streams.stream(aclService.getRoles())
                 .map(GqlAclRole::new)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get getCluster
+     *
+     * @return GqlCluster
+     */
+    @GraphQLField
+    @GraphQLDescription("Details about the Jahia cluster")
+    public GqlCluster getCluster() {
+
+        GqlCluster gqlCluster = new GqlCluster();
+        gqlCluster.setIsActivated(SettingsBean.getInstance().isClusterActivated());
+        return gqlCluster;
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlCluster.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlCluster.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName("Cluster")
+@GraphQLDescription("Details about the Jahia Cluster")
+public class GqlCluster {
+
+    private Boolean isActivated;
+
+    public GqlCluster() {
+    }
+
+    @GraphQLField
+    @GraphQLName("isActivated")
+    @GraphQLDescription("Is the cluster mode activated on this Jahia instance")
+    public Boolean getIsActivated() {
+        return isActivated;
+    }
+
+    public void setIsActivated(Boolean isActivated) {
+        this.isActivated = isActivated;
+    }
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaAdminQuery.java
@@ -119,6 +119,17 @@ public class GqlJahiaAdminQuery {
     }
 
     /**
+     * Get getJahiaSystem
+     *
+     * @return GqlJahiaSystem
+     */
+    @GraphQLField
+    @GraphQLDescription("Details about the system hosting Jahia")
+    public GqlJahiaSystem getSystem() {
+        return new GqlJahiaSystem();
+    }
+
+    /**
      * We must have at least one field for the schema to be valid
      *
      * @return true

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaAdminQuery.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaAdminQuery.java
@@ -25,15 +25,18 @@ import org.jahia.api.Constants;
 import org.jahia.bin.Jahia;
 import org.jahia.modules.graphql.provider.dxm.osgiconfig.GqlConfigurationQuery;
 import org.jahia.modules.graphql.provider.dxm.scheduler.GqlScheduler;
+import org.jahia.utils.DatabaseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.*;
-
 
 /**
  * GraphQL root object for Admin related queries.
@@ -84,6 +87,35 @@ public class GqlJahiaAdminQuery {
             logger.warn("Exception while parsing build date", e);
         }
         return gqlJahiaVersion;
+    }
+
+    /**
+     * Get getJahiaDatabase
+     *
+     * @return GqlJahiaDatabase
+     * @throws SQLException
+     */
+    @GraphQLField
+    @GraphQLDescription("Details about the database Jahia is connected to")
+    public GqlJahiaDatabase getDatabase() throws SQLException {
+        GqlJahiaDatabase gqlJahiaDatabase = new GqlJahiaDatabase();
+        gqlJahiaDatabase.setType(DatabaseUtils.getDatabaseType().toString());
+        Connection connection = null;
+        try {
+            connection = DatabaseUtils.getDatasource().getConnection();
+            DatabaseMetaData metadata = connection.getMetaData();
+        
+            gqlJahiaDatabase.setName(metadata.getDatabaseProductName());
+            gqlJahiaDatabase.setVersion(metadata.getDatabaseProductVersion());
+            gqlJahiaDatabase.setDriverName(metadata.getDriverName());
+            gqlJahiaDatabase.setDriverVersion(metadata.getDriverVersion());
+            gqlJahiaDatabase.setUrl(metadata.getURL());
+        } catch (Exception e) {
+            logger.error("Unable to get database information . Cause: " + e.getMessage(), e);
+        } finally {
+            DatabaseUtils.closeQuietly(connection);
+        }
+        return gqlJahiaDatabase;
     }
 
     /**

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaDatabase.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaDatabase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName("JahiaDatabase")
+@GraphQLDescription("Details about the database Jahia is connected to")
+public class GqlJahiaDatabase {
+
+    private String type;
+    private String name;
+    private String version;
+    private String driverName;
+    private String driverVersion;
+    private String url;
+
+    public GqlJahiaDatabase() {
+    }
+
+    @GraphQLField
+    @GraphQLName("type")
+    @GraphQLDescription("Type of database specified in Jahia configuration")
+    public String getType() {
+        return type;
+    }
+
+    @GraphQLField
+    @GraphQLName("name")
+    @GraphQLDescription("Name of the database vendor")
+    public String getName() {
+        return name;
+    }
+
+    @GraphQLField
+    @GraphQLName("version")
+    @GraphQLDescription("Version of the database")
+    public String getVersion() {
+        return version;
+    }
+
+    @GraphQLField
+    @GraphQLName("driverName")
+    @GraphQLDescription("Name of the driver used to connect to the database")
+    public String getDriverName() {
+        return driverName;
+    }
+
+    @GraphQLField
+    @GraphQLName("driverVersion")
+    @GraphQLDescription("Version of the driver used to connect to the database")
+    public String getDriverVersion() {
+        return driverVersion;
+    }
+
+    @GraphQLField
+    @GraphQLName("url")
+    @GraphQLDescription("url used to connect to the database")
+    public String getUrl() {
+        return url;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public void setDriverName(String driverName) {
+        this.driverName = driverName;
+    }
+
+    public void setDriverVersion(String driverVersion) {
+        this.driverVersion = driverVersion;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }    
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystem.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystem.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
+
+@GraphQLName("JahiaSystem")
+@GraphQLDescription("Details about the system used to run Jahia")
+public class GqlJahiaSystem {
+    public GqlJahiaSystem() {
+    }
+
+    @GraphQLField
+    @GraphQLName("property")
+    @GraphQLDescription("Get a system property by key")
+    public GqlJahiaSystemProperty getProperty(@GraphQLName("key") @GraphQLDescription("Java system property key") @GraphQLNonNull String key) {
+        GqlJahiaSystemProperty gqlJahiaSystemProperty = new GqlJahiaSystemProperty();
+        gqlJahiaSystemProperty.setKey(key);
+        gqlJahiaSystemProperty.setValue(System.getProperty(key));
+        return gqlJahiaSystemProperty;
+    }
+
+    /**
+     * Get getJahiaSystemOs
+     *
+     * @return GqlJahiaSystemOs
+     */
+    @GraphQLField
+    @GraphQLName("os")    
+    @GraphQLDescription("Details about the operating system")
+    public GqlJahiaSystemOs getSystemOs() {
+        GqlJahiaSystemOs gqlJahiaSystemOs = new GqlJahiaSystemOs();
+        gqlJahiaSystemOs.setName(System.getProperty("os.name"));
+        gqlJahiaSystemOs.setArchitecture(System.getProperty("os.arch"));
+        gqlJahiaSystemOs.setVersion(System.getProperty("os.version"));
+        return gqlJahiaSystemOs;
+    }
+
+    /**
+     * Get getJahiaSystemJava
+     *
+     * @return GqlJahiaSystemJava
+     */
+    @GraphQLField
+    @GraphQLName("java")    
+    @GraphQLDescription("Details about the operating system")
+    public GqlJahiaSystemJava getSystemJava() {
+        GqlJahiaSystemJava gqlJahiaSystemJava = new GqlJahiaSystemJava();
+        gqlJahiaSystemJava.setRuntimeName(System.getProperty("java.runtime.name"));
+        gqlJahiaSystemJava.setRuntimeVersion(System.getProperty("java.runtime.version"));
+        gqlJahiaSystemJava.setVendor(System.getProperty("java.vendor"));
+        gqlJahiaSystemJava.setVendorVersion(System.getProperty("java.vendor.version"));
+        return gqlJahiaSystemJava;
+    }   
+
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemJava.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemJava.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName("JahiaSystemJava")
+@GraphQLDescription("Details about the system OS used to run Jahia")
+public class GqlJahiaSystemJava {
+
+    private String runtimeName;
+    private String runtimeVersion;
+    private String vendor;
+    private String vendorVersion;
+
+    public GqlJahiaSystemJava() {
+    }
+
+    @GraphQLField
+    @GraphQLName("runtimeName")
+    @GraphQLDescription("Java Runtime name")
+    public String getRuntimeName() {
+        return runtimeName;
+    }
+
+    @GraphQLField
+    @GraphQLName("runtimeVersion")
+    @GraphQLDescription("Java Runtime version")
+    public String getRuntimeVersion() {
+        return runtimeVersion;
+    }
+
+    @GraphQLField
+    @GraphQLName("vendor")
+    @GraphQLDescription("Java vendor")
+    public String getVendor() {
+        return vendor;
+    }    
+
+    @GraphQLField
+    @GraphQLName("vendorVersion")
+    @GraphQLDescription("Java vendor version")
+    public String getVendorVersion() {
+        return vendorVersion;
+    }    
+
+    public void setRuntimeName(String runtimeName) {
+        this.runtimeName = runtimeName;
+    }
+
+    public void setRuntimeVersion(String runtimeVersion) {
+        this.runtimeVersion = runtimeVersion;
+    }    
+
+    public void setVendor(String vendor) {
+        this.vendor = vendor;
+    }
+
+    public void setVendorVersion(String vendorVersion) {
+        this.vendorVersion = vendorVersion;
+    }
+
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemOs.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemOs.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName("JahiaSystemOs")
+@GraphQLDescription("Details about the system OS used to run Jahia")
+public class GqlJahiaSystemOs {
+
+    private String name;
+    private String architecture;
+    private String version;
+
+    public GqlJahiaSystemOs() {
+    }
+
+    @GraphQLField
+    @GraphQLName("name")
+    @GraphQLDescription("Operating System Name")
+    public String getName() {
+        return name;
+    }
+
+    @GraphQLField
+    @GraphQLName("architecture")
+    @GraphQLDescription("Operating System Architecture (amd64, arm64, ...)")
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    @GraphQLField
+    @GraphQLName("version")
+    @GraphQLDescription("Operating System Version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setArchitecture(String architecture) {
+        this.architecture = architecture;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}
+
+

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemProperty.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/admin/GqlJahiaSystemProperty.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.admin;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+
+@GraphQLName("JahiaSystemProperty")
+@GraphQLDescription("Get a specific Java system property")
+public class GqlJahiaSystemProperty {
+
+    private String key;
+    private String value;
+
+    public GqlJahiaSystemProperty() {
+    }
+
+    @GraphQLField
+    @GraphQLName("key")
+    @GraphQLDescription("Java system property key")
+    public String getKey() {
+        return key;
+    }
+
+    @GraphQLField
+    @GraphQLName("value")
+    @GraphQLDescription("Java system property value")
+    public String getValue() {
+        return value;
+    }    
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}
+
+

--- a/tests/cypress/e2e/api/admin/cluster.cy.ts
+++ b/tests/cypress/e2e/api/admin/cluster.cy.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('Test admin jahia cluster endpoint', () => {
+    it('Gets cluster details', () => {
+        cy.apollo({
+            queryFile: 'admin/cluster.graphql',
+        }).should((response: any) => {
+            expect(response.data.admin.cluster.isActivated).to.equal(false)
+        })
+    })
+})

--- a/tests/cypress/e2e/api/admin/database.cy.ts
+++ b/tests/cypress/e2e/api/admin/database.cy.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('Test admin jahia database endpoint', () => {
+    it('Gets database details', () => {
+        cy.apollo({
+            queryFile: 'admin/database.graphql'
+        }).should((response: any) => {
+            expect(response.data.admin.jahia.database.type).to.equal('derby')
+
+            expect(response.data.admin.jahia.database.name).to.equal('Apache Derby')
+            expect(response.data.admin.jahia.database.version.length).to.greaterThan(8)
+
+            expect(response.data.admin.jahia.database.driverName).to.equal('Apache Derby Embedded JDBC Driver')
+            expect(response.data.admin.jahia.database.driverVersion.length).to.greaterThan(8)
+
+            expect(response.data.admin.jahia.database.url).to.equal('jdbc:derby:directory:/var/jahia/jahiadb')
+        })
+    })
+})

--- a/tests/cypress/e2e/api/admin/database.cy.ts
+++ b/tests/cypress/e2e/api/admin/database.cy.ts
@@ -3,7 +3,7 @@
 describe('Test admin jahia database endpoint', () => {
     it('Gets database details', () => {
         cy.apollo({
-            queryFile: 'admin/database.graphql'
+            queryFile: 'admin/database.graphql',
         }).should((response: any) => {
             expect(response.data.admin.jahia.database.type).to.equal('derby')
 

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -5,16 +5,16 @@ describe('Test admin jahia cluster endpoint', () => {
         const systemKey = 'karaf.base'
         cy.apollo({
             queryFile: 'admin/system.graphql',
-            variables: { systemKey: systemKey},
+            variables: { systemKey: systemKey },
         }).should((response: any) => {
             expect(response.data.admin.jahia.system.property.key).to.equal(systemKey)
-            expect(response.data.admin.jahia.system.property.value).to.equal("/var/jahia/karaf")
+            expect(response.data.admin.jahia.system.property.value).to.equal('/var/jahia/karaf')
 
-            expect(response.data.admin.jahia.system.os.name).to.equal("Linux")
+            expect(response.data.admin.jahia.system.os.name).to.equal('Linux')
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3)
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3)
 
-            expect(response.data.admin.jahia.system.java.runtimeName).to.equal("OpenJDK Runtime Environment")
+            expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment')
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3)
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3)
             expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3)

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('Test admin jahia cluster endpoint', () => {
+    it('Gets cluster details', () => {
+        const systemKey = 'karaf.base'
+        cy.apollo({
+            queryFile: 'admin/system.graphql',
+            variables: { systemKey: systemKey},
+        }).should((response: any) => {
+            expect(response.data.admin.jahia.system.property.key).to.equal(systemKey)
+            expect(response.data.admin.jahia.system.property.value).to.equal("/var/jahia/karaf")
+
+            expect(response.data.admin.jahia.system.os.name).to.equal("Linux")
+            expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3)
+            expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3)
+
+            expect(response.data.admin.jahia.system.java.runtimeName).to.equal("OpenJDK Runtime Environment")
+            expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3)
+            expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3)
+            expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3)
+        })
+    })
+})

--- a/tests/cypress/fixtures/admin/cluster.graphql
+++ b/tests/cypress/fixtures/admin/cluster.graphql
@@ -1,0 +1,7 @@
+query {
+  admin {
+    cluster {
+      isActivated
+    }
+  }
+}

--- a/tests/cypress/fixtures/admin/database.graphql
+++ b/tests/cypress/fixtures/admin/database.graphql
@@ -1,0 +1,14 @@
+query {
+  admin {
+    jahia {
+      database {
+        type
+        name
+        version
+        driverName
+        driverVersion
+        url
+      }
+    }
+  }
+}

--- a/tests/cypress/fixtures/admin/system.graphql
+++ b/tests/cypress/fixtures/admin/system.graphql
@@ -1,0 +1,24 @@
+query ($systemKey: String!) {
+  admin {
+    jahia {
+      system {
+        property(key: $systemKey) {
+        	key
+          value
+        }
+        os {
+          name
+          architecture
+          version
+        }
+        java {
+          runtimeName
+          runtimeVersion
+          vendor
+          vendorVersion
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Here's a sample query with the new fields:
```graphql
{
  admin {
    jahia {
      database {
        type
        name
        version
        driverName
        driverVersion
        url
      }
      system {
        property(key: "karaf.remoteShellPort") {
          key
          value
        }
        os {
          name
          architecture
          version
        }
        java {
          runtimeName
          runtimeVersion
          vendor
          vendorVersion
        }
      }
    }
    cluster {
      isActivated
    }
  }
}
```

Sample response:
```json

{
  "data": {
    "admin": {
      "jahia": {
        "database": {
          "type": "derby",
          "name": "Apache Derby",
          "version": "10.14.2.0 - (1828579)",
          "driverName": "Apache Derby Embedded JDBC Driver",
          "driverVersion": "10.14.2.0 - (1828579)",
          "url": "jdbc:derby:directory:/var/jahia/jahiadb"
        },
        "system": {
          "property": {
            "key": "karaf.remoteShellPort",
            "value": "8101"
          },
          "os": {
            "name": "Linux",
            "architecture": "amd64",
            "version": "5.4.0-1045-aws"
          },
          "java": {
            "runtimeName": "OpenJDK Runtime Environment",
            "runtimeVersion": "11.0.18+10",
            "vendor": "Eclipse Adoptium",
            "vendorVersion": "Temurin-11.0.18+10"
          }
        }
      },
      "cluster": {
        "isActivated": false
      }
    }
  }
}
```

Cypress tests are present for all these fields.

This require admin privileges, so I guess there's not issue with being able to fetch any system property, but if you do see an issue with that: `property(key: "karaf.remoteShellPort")`please let me know (the same is also available via the tools.