### PR TITLE
BACKLOG-7508: Add grant/revoke ACL role mutation API

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
@@ -22,6 +22,8 @@ package org.jahia.modules.graphql.provider.dxm.acl.service;/*
  * ==========================================================================================
  */
 
+import org.jahia.services.content.JCRNodeWrapper;
+
 import javax.jcr.RepositoryException;
 import java.util.List;
 
@@ -31,4 +33,33 @@ import java.util.List;
 public interface JahiaAclService {
 
     public List<JahiaAclRole> getRoles() throws RepositoryException;
+
+    /**
+     * Add GRANT permission on roleNames for a given node and principalKey
+     * Removes DENY permission or do nothing if node already has inherited role or has ACL inheritance break
+     *
+     * @param node to grant roleNames permissions
+     * @param principalKey one of <code>u:[username]</code> for users, or <code>g:[groupname]</code> for groups
+     * @param roleNames role names to add
+     * @return true if successful
+     * @throws RepositoryException
+     */
+    public boolean grantRoles(JCRNodeWrapper node, String principalKey, List<String> roleNames) throws RepositoryException;
+
+    /**
+     * Remove GRANT permission on roleNames for a given node and principalKey
+     * Add DENY permission if node has inherited role or has ACL inheritance break
+     *
+     * @param node to grant roleNames permissions
+     * @param principalKey one of <code>u:[username]</code> for users, or <code>g:[groupname]</code> for groups
+     * @param roleNames role names to revoke
+     * @return true if successful
+     * @throws RepositoryException
+     */
+    public boolean revokeRoles(JCRNodeWrapper node, String principalKey, List<String> roleNames) throws RepositoryException;
+
+    /**
+     * @return true if principalKey has GRANT permission on a roleName for a given node; false otherwise.
+     */
+    public boolean hasInheritedPermission(JCRNodeWrapper node, String principalKey, String roleName);
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
@@ -34,7 +34,9 @@ import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component(service = JahiaAclService.class, immediate = true)
 public class JahiaAclServiceImpl implements JahiaAclService {
@@ -42,6 +44,8 @@ public class JahiaAclServiceImpl implements JahiaAclService {
     public static final String JCR_ROLE_TYPE = "jnt:role";
     public static final String JCR_ROLEGROUP_TYPE = "j:roleGroup";
     public static final String JCR_ROLE_DEPENDENCIES_TYPE = "j:dependencies";
+
+    public static final String REMOVE = "REMOVE";
 
 
     public List<JahiaAclRole> getRoles() throws RepositoryException {
@@ -54,6 +58,48 @@ public class JahiaAclServiceImpl implements JahiaAclService {
             }
         }
         return roles;
+    }
+
+    public boolean grantRoles(JCRNodeWrapper jcrNode, String principalKey, List<String> roleNames) throws RepositoryException {
+        Map<String, String> roles = new HashMap<>(roleNames.size());
+        boolean breakInheritance = jcrNode.getAclInheritanceBreak();
+        for (String r: roleNames) {
+            roles.put(r, (breakInheritance || !hasInheritedPermission(jcrNode, principalKey, r)) ? Constants.GRANT : REMOVE);
+        }
+        return jcrNode.changeRoles(principalKey, roles);
+    }
+
+    public boolean revokeRoles(JCRNodeWrapper jcrNode, String principalKey, List<String> roleNames) throws RepositoryException {
+        Map<String, String> roles = new HashMap<>(roleNames.size());
+        boolean breakInheritance = jcrNode.getAclInheritanceBreak();
+        for (String r: roleNames) {
+            roles.put(r, (breakInheritance || hasInheritedPermission(jcrNode, principalKey, r)) ? Constants.DENY : REMOVE);
+        }
+        return jcrNode.changeRoles(principalKey, roles);
+    }
+
+    public boolean hasInheritedPermission(JCRNodeWrapper jcrNode, String principalKey, String roleName) {
+        Map<String, List<String[]>> acl = jcrNode.getAclEntries();
+        if (acl == null) {
+            return false;
+        }
+
+        List<String[]> permissions = acl.get(principalKey);
+        if (permissions == null || permissions.isEmpty()) {
+            return false;
+        }
+
+        for (String[] p: permissions) {
+            String fromAclPath = p[0];
+            String type = p[1];
+            String pRole = p[2];
+            if (!jcrNode.getPath().equals(fromAclPath)
+                    && roleName.equals(pRole)
+                    && Constants.GRANT.equals(type)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private NodeIterator execQuery(String query) throws RepositoryException {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
@@ -27,8 +27,13 @@ import org.jahia.api.Constants;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.decorator.JCRSiteNode;
+import org.jahia.services.usermanager.JahiaGroupManagerService;
+import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
@@ -40,6 +45,12 @@ import java.util.Map;
 
 @Component(service = JahiaAclService.class, immediate = true)
 public class JahiaAclServiceImpl implements JahiaAclService {
+
+    @Reference
+    private JahiaUserManagerService userService;
+
+    @Reference
+    private JahiaGroupManagerService groupService;
 
     public static final String JCR_ROLE_TYPE = "jnt:role";
     public static final String JCR_ROLEGROUP_TYPE = "j:roleGroup";
@@ -61,6 +72,9 @@ public class JahiaAclServiceImpl implements JahiaAclService {
     }
 
     public boolean grantRoles(JCRNodeWrapper jcrNode, String principalKey, List<String> roleNames) throws RepositoryException {
+        if (!isValidPrincipal(jcrNode, principalKey)) {
+            throw new ItemNotFoundException("Invalid user");
+        }
         Map<String, String> roles = new HashMap<>(roleNames.size());
         boolean breakInheritance = jcrNode.getAclInheritanceBreak();
         for (String r: roleNames) {
@@ -76,6 +90,23 @@ public class JahiaAclServiceImpl implements JahiaAclService {
             roles.put(r, (breakInheritance || hasInheritedPermission(jcrNode, principalKey, r)) ? Constants.DENY : REMOVE);
         }
         return jcrNode.changeRoles(principalKey, roles);
+    }
+
+    private boolean isValidPrincipal(JCRNodeWrapper jcrNode, String principalKey) throws RepositoryException {
+        String siteKey = null;
+        JCRSiteNode site = jcrNode.getResolveSite();
+        if (site != null) {
+            siteKey = site.getSiteKey();
+        }
+
+        String[] principalItems = principalKey.split(":");
+        boolean isValid = false;
+        if ("u".equals(principalItems[0])) {
+            isValid = userService.lookupUser(principalItems[1], siteKey) != null;
+        } else if ("g".equals(principalItems[0])) {
+            isValid = groupService.lookupGroup(siteKey, principalItems[1]) != null;
+        }
+        return isValid;
     }
 
     public boolean hasInheritedPermission(JCRNodeWrapper jcrNode, String principalKey, String roleName) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/PrincipalType.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/PrincipalType.java
@@ -1,0 +1,51 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2023 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.graphql.provider.dxm.user;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+
+@GraphQLDescription("Principal type")
+public enum PrincipalType {
+
+    @GraphQLDescription("User principal type")
+    USER("u"),
+
+    @GraphQLDescription("Group principal type")
+    GROUP("g");
+
+    private final String principalType;
+
+
+    PrincipalType(String principalType) {
+        this.principalType = principalType;
+    }
+
+    public String getValue() {
+        return principalType;
+    }
+
+    public String getPrincipalKey(String principalName) {
+        return String.join(":", getValue(), principalName);
+    }
+}

--- a/tests/cypress/e2e/api/acl/aclRoles.cy.ts
+++ b/tests/cypress/e2e/api/acl/aclRoles.cy.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-describe('Test admin roles endpoint', () => {
+describe('Test admin roles query endpoint', () => {
     it('gets ACL roles', () => {
         cy.apollo({
             queryFile: 'acl/getRoles.graphql',

--- a/tests/cypress/e2e/api/acl/setAclRoles.cy.ts
+++ b/tests/cypress/e2e/api/acl/setAclRoles.cy.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { grantUserRole, revokeUserRole } from '../../../fixtures/acl'
+
+describe('Test grant/revoke role mutation on node endpoint', () => {
+    const parentPath = '/sites/digitall/files/images'
+    const pathOrId = `${parentPath}/placeholder.jpg`
+
+    it('grant role on node', () => {
+        const role = 'editor'
+        const user = 'jay'
+
+        cy.log('Calling grantRoles graphql api')
+        grantUserRole(pathOrId, role, user)
+
+        cy.log(`Verify role '${role}' has been added to node ${pathOrId}`)
+        cy.apollo({
+            queryFile: 'acl/getAceNode.graphql',
+            variables: { pathOrId },
+        }).should((resp) => {
+            const acls = resp?.data?.jcr?.nodeByPath?.descendants?.nodes || []
+            const userAcl = acls.find((a) => a.principal.value === `u:${user}`)
+            expect(userAcl, `Found ACE for user ${user}`).to.be.not.undefined
+            expect(userAcl.roles.values).to.contain(role, 'ACE has ${role} role')
+            expect(userAcl.aceType.value).equals('GRANT', 'ACE has GRANT permission ${role} role')
+        })
+    })
+
+    it('remove role on revokeRole operation that has been added on node', () => {
+        const role = 'editor'
+        const user = 'jay'
+
+        cy.log('Calling revokeRoles graphql api')
+        revokeUserRole(pathOrId, role, user)
+
+        cy.log(`Verify role '${role}' has been removed from node ${pathOrId}`)
+        cy.apollo({
+            queryFile: 'acl/getAceNode.graphql',
+            variables: { pathOrId },
+        }).should((resp) => {
+            const acls = resp?.data?.jcr?.nodeByPath?.descendants?.nodes || []
+            const userAcl = acls.find((a) => a.principal.value === `u:${user}`)
+            expect(userAcl, `ACE for user ${user} has been removed on node ${pathOrId}`).to.be.undefined
+        })
+    })
+
+    it('add DENY on revokeRole operation if node has inherited permissions', () => {
+        const role = 'editor-in-chief'
+        const user = 'jay'
+
+        cy.log('Grant role on parent node')
+        grantUserRole(parentPath, role, user)
+
+        cy.log('Revoke role on a child node')
+        revokeUserRole(pathOrId, role, user)
+
+        cy.log(`Verify role '${role}' has deny permission on node ${pathOrId}`)
+        cy.apollo({
+            queryFile: 'acl/getAceNode.graphql',
+            variables: { pathOrId },
+        }).should((resp) => {
+            const acls = resp?.data?.jcr?.nodeByPath?.descendants?.nodes || []
+            const userAcl = acls.find((a) => a.principal.value === `u:${user}`)
+            expect(userAcl, `ACE for user ${user} has been removed`).to.be.not.undefined
+            expect(userAcl.roles.values).to.contain(role, 'ACE has ${role} role')
+            expect(userAcl.aceType.value).equals('DENY', 'ACE has DENY permission ${role} role')
+        })
+    })
+
+    it('remove DENY permission on grantRole operation if user has inherited role', () => {
+        const role = 'editor-in-chief'
+        const user = 'jay'
+
+        cy.log('Grant role on a child node')
+        grantUserRole(pathOrId, role, user)
+
+        cy.log(`Verify DENY permission on role '${role}' has been removed on node ${pathOrId}`)
+        cy.apollo({
+            queryFile: 'acl/getAceNode.graphql',
+            variables: { pathOrId },
+        }).should((resp) => {
+            const acls = resp?.data?.jcr?.nodeByPath?.descendants?.nodes || []
+            const userAcl = acls.find((a) => a.principal.value === `u:${user}`)
+            expect(userAcl, `ACE for user ${user} has been removed`).to.be.undefined
+        })
+    })
+
+    it('do nothing on grantRole operation if user has inherited role', () => {
+        const role = 'editor-in-chief'
+        const user = 'jay'
+
+        cy.log('Grant role on a child node')
+        grantUserRole(pathOrId, role, user)
+
+        cy.log(`Verify GRANT role '${role}' not added on node ${pathOrId}`)
+        cy.apollo({
+            queryFile: 'acl/getAceNode.graphql',
+            variables: { pathOrId },
+        }).should((resp) => {
+            const acls = resp?.data?.jcr?.nodeByPath?.descendants?.nodes || []
+            const userAcl = acls.find((a) => a.principal.value === `u:${user}`)
+            expect(userAcl, `No grant role added for user ${user}`).to.be.undefined
+        })
+    })
+
+    it('revoke GRANT permission on parent node', () => {
+        revokeUserRole(parentPath, 'editor-in-chief', 'jay')
+    })
+})

--- a/tests/cypress/fixtures/acl/getAceNode.graphql
+++ b/tests/cypress/fixtures/acl/getAceNode.graphql
@@ -1,0 +1,20 @@
+
+query getAce($pathOrId:String!) {
+    jcr {
+        nodeByPath(path: $pathOrId) {
+            descendants(typesFilter:{types:["jnt:ace"]}) {
+                nodes {
+                    principal: property(name:"j:principal") {
+                        value
+                    }
+                    aceType: property(name:"j:aceType") {
+                        value
+                    }
+                    roles: property(name:"j:roles") {
+                        values
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/acl/grantRoles.graphql
+++ b/tests/cypress/fixtures/acl/grantRoles.graphql
@@ -1,0 +1,7 @@
+mutation grantRoles($pathOrId:String!, $roles:[String!]!, $pType:PrincipalType!,$pName:String!) {
+    jcr {
+        mutateNode(pathOrId: $pathOrId) {
+            grantRoles(roleNames: $roles, principalType: $pType, principalName: $pName)
+        }
+    }
+}

--- a/tests/cypress/fixtures/acl/index.ts
+++ b/tests/cypress/fixtures/acl/index.ts
@@ -1,0 +1,29 @@
+export function grantUserRole(pathOrId, roleName, userName) {
+    return grantRoles({ pathOrId, roles: [roleName], pType: 'USER', pName: userName })
+}
+
+function grantRoles(apiParams) {
+    return cy
+        .apollo({
+            mutationFile: 'acl/grantRoles.graphql',
+            variables: apiParams,
+        })
+        .should((resp) => {
+            expect(resp?.data?.jcr?.mutateNode?.grantRoles, 'Grant role request OK').to.be.true
+        })
+}
+
+export function revokeUserRole(pathOrId, roleName, userName) {
+    return revokeRoles({ pathOrId, roles: [roleName], pType: 'USER', pName: userName })
+}
+
+function revokeRoles(apiParams) {
+    return cy
+        .apollo({
+            mutationFile: 'acl/revokeRoles.graphql',
+            variables: apiParams,
+        })
+        .should((resp) => {
+            expect(resp?.data?.jcr?.mutateNode?.revokeRoles, 'Revoke role request OK').to.be.true
+        })
+}

--- a/tests/cypress/fixtures/acl/revokeRoles.graphql
+++ b/tests/cypress/fixtures/acl/revokeRoles.graphql
@@ -1,0 +1,7 @@
+mutation revokeRoles($pathOrId:String!, $roles:[String!]!, $pType:PrincipalType!,$pName:String!) {
+    jcr {
+        mutateNode(pathOrId: $pathOrId) {
+            revokeRoles(roleNames: $roles, principalType: $pType, principalName: $pName)
+        }
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-7508

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added new endpoint as per spec:

```
extends type JCRNodeMutation {
     grantRoles(roleNames: [String]!, principalType: PrincipalType, principalName: String): Boolean
     revokeRoles(roleNames: [String]!, principalType: PrincipalType, principalName: String): Boolean
}
```

where `PrincipalType` can either be `USER` or `GROUP`

grant/revoke logic extracted from CE advanced options > roles dialog: https://github.com/Jahia/jahia-private/blob/master/core/src/main/java/org/jahia/ajax/gwt/helper/ContentManagerHelper.java#L992

- Also added check if principal is valid within site context of the node, or is a global user. Throws error if invalid