### PR TITLE
BACKLOG-20612: Fix global lookup for users/groups on aclEntries endpoint

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/PrincipalInput.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/PrincipalInput.java
@@ -63,6 +63,9 @@ public class PrincipalInput {
             principal = (userNode != null) ? new GqlUser(userNode.getJahiaUser()) : null;
         } else if (principalType == PrincipalType.GROUP && groupService != null) {
             JCRGroupNode groupNode = groupService.lookupGroup(siteKey, principalName);
+            if (groupNode == null) {
+                groupNode = groupService.lookupGroup(null, principalName); // Try searching global groups
+            }
             principal = (groupNode != null) ? new GqlGroup(groupNode.getJahiaGroup()) : null;
         }
         return principal;

--- a/tests/cypress/e2e/api/acl/aclEntries.cy.ts
+++ b/tests/cypress/e2e/api/acl/aclEntries.cy.ts
@@ -70,7 +70,22 @@ describe('Test ACL/ACE query endpoint', () => {
         })
     })
 
-    function getRole(ace, userName, roleName) {
-        return ace.find((a) => a.principal?.name === userName && a.aclEntryType === 'GRANT' && a.role.name === roleName)
+    it('Get ACL for specific global group', () => {
+        const principalFilter = { type: 'GROUP', name: 'users' }
+        getAclEntries(path, principalFilter).should((resp) => {
+            const acl = resp?.data?.jcr?.nodeByPath?.acl
+            expect(acl).to.exist
+            expect(acl.aclEntries).to.be.not.empty
+            const aclEntry = getRole(acl.aclEntries, 'users', 'reader')
+            expect(aclEntry, `'users' group has a reader role for ${path}`).to.be.not.undefined
+            expect(aclEntry.inherited).to.be.true
+            expect(aclEntry.inheritedFrom.path, "'users' group is defined globally").equals('/')
+        })
+    })
+
+    function getRole(ace, principalName, roleName) {
+        return ace.find(
+            (a) => a.principal?.name === principalName && a.aclEntryType === 'GRANT' && a.role.name === roleName,
+        )
     }
 })


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20612

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Need to search global groups if not found within site
  - Added cypress test case for global groups