### PR TITLE
QA-15005: Add GraphQL field to know if node is external (has in not under the default provider)

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNode.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNode.java
@@ -303,6 +303,11 @@ public interface GqlJcrNode {
     DXPaginatedData<GqlUsage> getUsages(@GraphQLName("fieldFilter") @GraphQLDescription("Filter by graphQL fields values") FieldFiltersInput fieldFilter,
                                           @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,
                                           DataFetchingEnvironment environment);
+    @GraphQLField
+    @GraphQLNonNull
+    @GraphQLName("isExternal")
+    @GraphQLDescription("true if node is under a mounted node")
+    boolean isExternal();
 
     /**
      * Nodes filter based on their types.

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
@@ -577,6 +577,15 @@ public class GqlJcrNodeImpl implements GqlJcrNode {
         return PaginationHelper.paginate(result, u -> PaginationHelper.encodeCursor(u.getNode().getUuid()), arguments);
     }
 
+
+    @Override
+    @GraphQLNonNull
+    @GraphQLName("isExternal")
+    @GraphQLDescription("true if node is under a mounted node")
+    public boolean isExternal() {
+        return !node.getProvider().isDefault();
+    }
+
     private void collectUsages(PropertyIterator references, Collection<GqlUsage> gqlReferences, DataFetchingEnvironment environment) throws RepositoryException {
         while (references.hasNext()) {
             JCRPropertyWrapper reference = (JCRPropertyWrapper) references.nextProperty();


### PR DESCRIPTION

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15005

## Description

Adding an isExternal field on GqlJCRNode to know if a node is external or not. This will allow to hide/show actions in UI once useNodeChecks and UseNodeInfo are updated in data-helper


