### PR TITLE
BACKLOG-22056: Spike for GraphQL field for richtext nice URLs (Approach One with URL Traverser)

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrProperty.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrProperty.java
@@ -518,9 +518,9 @@ public class GqlJcrProperty {
             renderContext.setWorkspace(node.getSession().getWorkspace().getName());
             renderContext.setSite(node.getResolveSite());
             renderContext.setMainResource(r);
-            renderContext.setServletPath("/cms/edit");
+            renderContext.setServletPath("/cms/render");
             if (request.getAttribute("currentMode") == null) {
-                request.setAttribute("currentMode", renderContext.getMode());
+                request.setAttribute("currentMode", renderContext.getMode() + "/" + node.getSession().getWorkspace().getName());
             }
             new URLGenerator(renderContext, r);
             if (JCRContentUtils.isADisplayableNode(node, renderContext)) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

https://jira.jahia.org/browse/BACKLOG-22056

## Description

Spike to test the use of URLTraverser to be able to interpret richText property embedded URLs and return a rendered version instead of the stored one that include variable reference in some path segment (aka: /sites/{mode}/{lang})
The URLTraverser is retrieved using OSGI injection.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
