### PR TITLE
TECH-1597: Bump graphql version to 3.0.0; install workarounds for SDL extension issues

### DIFF
--- a/graphql-dxm-provider/package.json
+++ b/graphql-dxm-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/graphql-dxm-provider",
-  "version": "2.20.0-SNAPSHOT",
+  "version": "3.0.0-SNAPSHOT",
   "husky": {
     "hooks": {
       "pre-push": "yarn lint:fix"

--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.20.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-dxm-provider</artifactId>
     <name>Jahia GraphQL Core Provider</name>
@@ -52,7 +52,7 @@
             org.apache.tika;version="[1.27,3)"
         </import-package>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFF+OA2JTSs4XZqAlfoP157UxsrxYAhQbILGqUYsZyQ0ZdSM9hZzA0S4z+g==</jahia-module-signature>
+        <jahia-module-signature>MCwCFH3Jo1W5aXYk+kW7A2dRUBxOg2q3AhR15zsTLj2EyRodLNbRf9JFkKK2aw==</jahia-module-signature>
         <mockito.version>2.21.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <yarn.arguments>build:production</yarn.arguments>

--- a/graphql-extension-example/pom.xml
+++ b/graphql-extension-example/pom.xml
@@ -21,12 +21,16 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.20.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-extension-example</artifactId>
     <name>Jahia GraphQL Extension example</name>
     <packaging>bundle</packaging>
     <description>This is the provider project for the DX GraphQL Core integration project</description>
+
+    <properties>
+        <jahia-module-signature>MCwCFHWxEqchldFpwkJr6ZmFPtWpi7FoAhQ3dFCWiISPvp9zWONphGzNtpyS2g==</jahia-module-signature>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -79,7 +83,6 @@
                             org.glassfish.jersey.server,
                             *
                         </Import-Package>
-                        <jahia-module-signature>MCwCFFKVMxV9By/nvxGYKh6rrFslPR7mAhQ2SHknabRWEAtrpzbVNI4M5EIXwQ==</jahia-module-signature>
                     </instructions>
                 </configuration>
             </plugin>

--- a/graphql-extension-example/src/main/resources/META-INF/graphql-extension.sdl
+++ b/graphql-extension-example/src/main/resources/META-INF/graphql-extension.sdl
@@ -1,3 +1,5 @@
+directive @mapping(node : String, property: String, ignoreDefaultQueries: Boolean) on FIELD_DEFINITION
+
 """This is news"""
 type NewsSDL @mapping(node:"jnt:news", ignoreDefaultQueries: true) {
     """This is title"""

--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -21,24 +21,28 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>2.20.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-test</artifactId>
     <groupId>org.jahia.test</groupId>
     <name>Jahia GraphQL Test Module</name>
     <packaging>bundle</packaging>
 
+    <properties>
+        <jahia-module-signature>MCwCFCyaKhNKLLhHt0XUvZi5UJT15BB6AhQgkJkrQ3c4KBIF7JdwvAKTNN3W8g==</jahia-module-signature>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jahia.server</groupId>
             <artifactId>jahia-impl</artifactId>
-            <version>8.1.1.0</version>
+            <version>8.2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jahia.test</groupId>
             <artifactId>jahia-test-module</artifactId>
-            <version>8.1.0.0</version>
+            <version>8.2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -50,7 +54,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>2.20.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -104,7 +108,6 @@
                 <configuration>
                     <instructions>
                         <Import-Package>${jahia.plugin.projectPackageImport},javax.jcr,*</Import-Package>
-                        <jahia-module-signature>MCwCFCMl3udP9hN6kRh5nISfleEU9MixAhR0ievhUO7y1+TjJp1+oOkmXdXCeQ==</jahia-module-signature>
                         <Require-Capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</Require-Capability>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <artifactId>graphql-core-root</artifactId>
     <name>Jahia GraphQL Core Root</name>
-    <version>2.20.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the root project for the DX GraphQL Core integration project</description>
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1597

Also fixed an issue relating to incorrect signature on graphql-extension-example which revealed (multiple) issues relating to directives and SDL extensions not working (still being investigated; creating a new ticket). 

For now we explicitly declare `@mapping` directive in the graphql-extension.sdl to workaround install issues but SDL types/queries are still not available.

Fixed one of the issues relating to graphql-java upgrade that is throwing exceptions.

In graphql-java v21, the code:

```ObjectTypeExtensionDefinition.getFieldDefinitions().removeAll(fieldDefinitions)``` now throws an exception as `getFieldDefinitions()` is now returning an immutable list. This throws an exception when calling `removeAll()` and is corrupting the schema. Needed to adapt code to use `transformExtension` instead



