### PR TITLE
QA-15089: Excluded SAM API nodes from the description test

### DIFF
--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -43,7 +43,10 @@ describe('Test if every type in graphQL API has description', () => {
                     'type=Category/field=path',
                     'type=Query/field=categoryByPath/arg=path',
                     'type=GqlNpmHelper',
-                    'type=GqlHealthCheck'
+                    'type=GqlHealthCheck',
+                    'type=GqlProbe',
+                    'type=JahiaAdminQuery/field=healthCheck',
+                    'type=LoadValue/field=healthCheck'
                 ];
                 noDescBlacklist.forEach(n => noDesc.delete(n));
 

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -42,7 +42,8 @@ describe('Test if every type in graphQL API has description', () => {
                     'type=Category/field=uuid',
                     'type=Category/field=path',
                     'type=Query/field=categoryByPath/arg=path',
-                    'type=GqlNpmHelper'
+                    'type=GqlNpmHelper',
+                    'type=GqlHealthCheck'
                 ];
                 noDescBlacklist.forEach(n => noDesc.delete(n));
 


### PR DESCRIPTION
SAM was added to the build which is triggering some failures of the API description test.

The API Description test is already part of SAM tests and it shouldn't be the responsibility of graphql-core to test these descriptions.