### PR TITLE
BACKLOG-22337: Implement new GraphQLDirectiveProvider for validation

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -50,7 +50,10 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
 @Component(service = GraphQLProvider.class, immediate = true)
-public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProvider, GraphQLMutationProvider, GraphQLSubscriptionProvider, GraphQLCodeRegistryProvider, DXGraphQLExtensionsProvider {
+public class DXGraphQLProvider implements
+        GraphQLTypesProvider, GraphQLQueryProvider, GraphQLMutationProvider, GraphQLDirectiveProvider,
+        GraphQLSubscriptionProvider, GraphQLCodeRegistryProvider, DXGraphQLExtensionsProvider
+{
     private static Logger logger = LoggerFactory.getLogger(DXGraphQLProvider.class);
 
     private static DXGraphQLProvider instance;
@@ -302,6 +305,11 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         types.addAll(specializedTypesHandler.getKnownTypes().values());
         types.addAll(sdlSchemaService.getSDLTypes());
         return types;
+    }
+
+    @Override
+    public Collection<GraphQLDirective> getDirectives() {
+        return sdlSchemaService.getDirectives();
     }
 
     @Override

--- a/graphql-extension-example/src/main/resources/META-INF/graphql-extension.sdl
+++ b/graphql-extension-example/src/main/resources/META-INF/graphql-extension.sdl
@@ -1,5 +1,3 @@
-directive @mapping(node : String, property: String, ignoreDefaultQueries: Boolean) on FIELD_DEFINITION
-
 """This is news"""
 type NewsSDL @mapping(node:"jnt:news", ignoreDefaultQueries: true) {
     """This is title"""

--- a/tests/cypress/e2e/sdl/sdlExtensions.cy.js
+++ b/tests/cypress/e2e/sdl/sdlExtensions.cy.js
@@ -1,0 +1,33 @@
+import {
+    getCoreSdlExtensions,
+    getExampleSdlExtensions
+} from '../../fixtures/sdl/sdlExtensions';
+
+describe('SDL extensions', () => {
+    it('should have SDL extensions defined in dxm-provider module', () => {
+        cy.apollo({query: getCoreSdlExtensions}).then((response) => {
+            const {category, imageAsset} = response?.data || {};
+            expect(category?.fields?.map(f => f.name)).to.deep.eq(
+                ['metadata', 'description', 'title']
+            );
+            expect(imageAsset?.fields?.map(f => f.name)).to.deep.eq(
+                ['metadata', 'type', 'size', 'height', 'width']
+            );
+        });
+    });
+
+    it('should have SDL extensions defined in extension-examples module', () => {
+        cy.apollo({query: getExampleSdlExtensions}).then((response) => {
+            const {newsSdl, images, queries} = response?.data || {};
+            expect(newsSdl?.fields?.map(f => f.name)).to.deep.eq(
+                ['metadata', 'description', 'title']
+            );
+            expect(images?.fields?.map(f => f.name)).to.deep.eq(
+                ['metadata', 'type', 'size', 'height', 'width']
+            );
+            ['newsByChecked', 'myNewsByDate', 'myImagesByHeight'].forEach(queryField => {
+                expect(queries?.fields?.find(f => f.name === queryField)).to.exist;
+            });
+        });
+    });
+});

--- a/tests/cypress/fixtures/sdl/sdlExtensions.js
+++ b/tests/cypress/fixtures/sdl/sdlExtensions.js
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+export const getCoreSdlExtensions = gql`
+    query coreSdlExtensions {
+        category: __type(name: "Category") {
+            fields {name}
+        },
+        imageAsset: __type(name: "ImageAsset") {
+            fields {name}
+        }
+    }
+`;
+
+export const getExampleSdlExtensions = gql`
+    query exampleSdlExtensions {
+        newsSdl: __type(name:"NewsSDL") {
+            fields {name}
+        }
+        images: __type(name:"Images") {
+            fields {name}
+        }
+        queries: __type(name: "Query") {
+            fields {name}
+        }
+    }
+`;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22337

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

graphql-java-servlet has been patched to include custom directive definitions when building/validating schema (PR [here](https://github.com/Jahia/graphql-java-servlet/commit/eb553e64f06111c3843fa2bc4a409d7034a74c6e) and here) and here).

Implement this new provider in graphql-core and fix validation issues to make SDL extensions work again.

Also added cypress test to check for SDL extensions defined in core graphql-extension-examples