### PR TITLE
TECH-1631: Updated the tests for GraphQL API descriptions

### DIFF
--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -31,7 +31,7 @@ describe('Test for GraphQL schema description', () => {
 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket: BACKLOG-22338
-        'jcr/JCRQuery/nodeById/JCRNode/findAvailableNodeName/',
+        'JCRNode/findAvailableNodeName/',        
         'InputFieldFiltersInput/multi/MulticriteriaEvaluation',
         'InputFieldSorterInput/sortType/SortType',
         'InputFieldGroupingInput/groupingType/GroupingType',

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -31,7 +31,7 @@ describe('Test for GraphQL schema description', () => {
 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket: BACKLOG-22338
-        'JCRNode/findAvailableNodeName/',
+        'findAvailableNodeName',
         'InputFieldFiltersInput/multi/MulticriteriaEvaluation',
         'InputFieldSorterInput/sortType/SortType',
         'InputFieldGroupingInput/groupingType/GroupingType',

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -28,6 +28,9 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket:
         'Query/WorkflowService',
+        'Query/categoryById/id',
+        'Query/categoryByPath/path',
+        'Query/AdminQuery/UserAdminQuery/User',
         'Mutation/AdminMutation/JahiaAdminMutation/GqlConfigurationMutation',
         'Mutation/JCRMutation',
         'Mutation/WorkflowMutation',
@@ -49,7 +52,7 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
 
                 noDesc.forEach(graphqlType => {
                     cy.log('Missing description for node at path: ' + graphqlType.nodePath.join('/'));
-                    console.log('Missing description for type: ' + graphqlType.name + ' in path: ' + graphqlType.nodePath.join('/'), graphqlType);
+                    console.log(graphqlType.nodePath.join('/'));
                 });
                 cy.then(() => expect(noDesc.length).to.equal(0));
             });

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -17,9 +17,12 @@ describe('Test for GraphQL schema description', () => {
         'GqlDashboard',
 
         // Missing but provided by: https://github.com/Jahia/server-availability-manager
-        'AdminQuery/JahiaAdminQuery/healthCheck',
-        'AdminQuery/JahiaAdminQuery/GqlHealthCheck',
-        'AdminQuery/JahiaAdminQuery/Load',
+        'AdminQuery/jahia/JahiaAdminQuery/healthCheck',
+        'AdminQuery/jahia/JahiaAdminQuery/GqlHealthCheck',
+        'AdminQuery/jahia/JahiaAdminQuery/load',
+
+        // Missing but provided by: https://github.com/Jahia/personal-api-tokens
+        'AdminQuery/personalApiTokens/PersonalApiTokensQuery',
 
         // Missing but provided by: https://github.com/Jahia/security-filter-tools
         'JWTToken',
@@ -27,18 +30,22 @@ describe('Test for GraphQL schema description', () => {
 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket: BACKLOG-22338
-        'Query/categoryById/id',
-        'Query/categoryByPath/path',
-        'findAvailableNodeName',
-        'MulticriteriaEvaluation',
-        'SortType',
-        'WipStatus',
-        'Mutation/AdminMutation/JahiaAdminMutation/GqlConfigurationMutation',
-        'Mutation/JCRMutation',
-        'Mutation/WorkflowMutation',
+        'jcr/JCRQuery/nodeById/JCRNode/findAvailableNodeName/',
+        'InputFieldFiltersInput/multi/MulticriteriaEvaluation',
+        'InputFieldSorterInput/sortType/SortType',
+        'InputFieldGroupingInput/groupingType/GroupingType',
+        'JCRProperty/type/JCRPropertyType',
+        'GqlPublicationInfo/publicationStatus/PublicationStatus',
+        'wipInfo/status/WipStatus',
+        'GqlBackgroundJob/jobState/GqlBackgroundJobState',
+        'GqlBackgroundJob/jobStatus/GqlBackgroundJobStatus',
+
         'Mutation/mutateWorkflows',
-        'Subscription/workflowEvent/GqlWorkflowEvent',
-        'Subscription/backgroundJobSubscription'
+        'configuration/GqlConfigurationMutation',
+        'AdminMutation/personalApiTokens',
+        'Mutation/jcr/JCRMutation',
+
+        'Subscription/workflowEvent/GqlWorkflowEvent'
     ];
 
     const entryNodes = ['Query', 'Mutation', 'Subscription'];
@@ -58,6 +65,19 @@ describe('Test for GraphQL schema description', () => {
                     console.log(`Missing description for ${description.schemaType} at path: ${description.nodePath.join('/')}`);
                 });
                 cy.then(() => expect(noDesc.length).to.equal(0));
+
+                // Get the list of nodes that are deprecated and ensure an explanation is present (deprecationReason)*
+                // "Deprecated" (in all its forms) is not considered a valid deprecationReason
+                // Remove the nodes that are in the blacklist 
+                const noDeprecateReason = result
+                    .filter((graphqlType => (graphqlType.isDeprecated === true && (!graphqlType.deprecationReason || graphqlType.deprecationReason.length === 0 || (graphqlType.deprecationReason instanceof String && graphqlType.deprecationReason.toLowercase() === ("Deprecated").toLowerCase())))))
+                    .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))));
+
+                    noDeprecateReason.forEach(description => {
+                    cy.log(`Deprecated ${description.schemaType} missing explanation at path: ${description.nodePath.join('/')}`);
+                    console.log(`Deprecated ${description.schemaType} missing explanation at path: ${description.nodePath.join('/')}`);
+                });
+                cy.then(() => expect(noDesc.length).to.equal(0));                
             });
         });
     });

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -2,7 +2,7 @@
 
 import {getDescriptions} from '@jahia/cypress';
 
-describe('Test if every all nodes of the GraphQL schema have a description', () => {
+describe('Test for GraphQL schema description', () => {
     // The blacklist is used to ignore nodes that are not registered directly by graphql-core
     // These descriptions should be added in their respective codebases
     const noDescBlacklist = [
@@ -43,7 +43,7 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
 
     const entryNodes = ['Query', 'Mutation', 'Subscription'];
     entryNodes.forEach(entryNode => {
-        it(`Verify presence of a description all nodes under ${entryNode}`, () => {
+        it(`Description for all nodes under ${entryNode}`, () => {
             getDescriptions(entryNode).then(result => {
                 console.log(result);
 

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -9,7 +9,7 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
         // Missing but provided by: https://github.com/Jahia/npm-modules-engine
         'GqlNpmHelper',
 
-        // Missing but provided by:  https://github.com/Jahia/content-editor or https://github.com/Jahia/jcontent
+        // // Missing but provided by:  https://github.com/Jahia/content-editor or https://github.com/Jahia/jcontent
         'GqlEditorForms',
         'GqlEditorForm',
 
@@ -27,15 +27,18 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket:
-        'Query/WorkflowService',
         'Query/categoryById/id',
         'Query/categoryByPath/path',
-        'Query/AdminQuery/UserAdminQuery/User',
+        'findAvailableNodeName',
+        'MulticriteriaEvaluation',
+        'SortType',
+        'WipStatus',
         'Mutation/AdminMutation/JahiaAdminMutation/GqlConfigurationMutation',
         'Mutation/JCRMutation',
         'Mutation/WorkflowMutation',
         'Mutation/mutateWorkflows',
-        'Subscription/GqlWorkflowEvent'
+        'Subscription/workflowEvent/GqlWorkflowEvent',
+        'Subscription/backgroundJobSubscription'
     ];
 
     const entryNodes = ['Query', 'Mutation', 'Subscription'];
@@ -50,9 +53,9 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
                     .filter((graphqlType => graphqlType.description === null || graphqlType.description.length === 0))
                     .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))));
 
-                noDesc.forEach(graphqlType => {
-                    cy.log('Missing description for node at path: ' + graphqlType.nodePath.join('/'));
-                    console.log(graphqlType.nodePath.join('/'));
+                noDesc.forEach(description => {
+                    cy.log(`Missing description for ${description.schemaType} at path: ${description.nodePath.join('/')}`);
+                    console.log(`Missing description for ${description.schemaType} at path: ${description.nodePath.join('/')}`);
                 });
                 cy.then(() => expect(noDesc.length).to.equal(0));
             });

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -1,213 +1,57 @@
-import gql from 'graphql-tag';
+import {getDescriptions} from '@jahia/cypress';
 
-describe('Test if every type in graphQL API has description', () => {
-    it('Check every input for the User Type', () => {
-        const types = new Set();
-        const noDesc = new Set();
-        const invalidNames = new Set();
+describe('Test if every all nodes of the GraphQL schema have a description', () => {
+    // The blacklist is used to ignore nodes that are not registered directly by graphql-core
+    // These descriptions should be added in their respective codebases
+    const noDescBlacklist = [
+        // Missing but provided by: https://github.com/Jahia/npm-modules-engine
+        'GqlNpmHelper', 
 
-        cy.apolloClient()
-            .then({timeout: 25000}, client => executeTest(client, 'Query', types, noDesc, invalidNames))
-            .should(() => {
-                const noDescBlacklist = [
-                    'type=JCRSite/field=findAvailableNodeName/arg=nodeType',
-                    'type=JCRSite/field=findAvailableNodeName/arg=language',
-                    'type=VanityUrl/field=findAvailableNodeName/arg=nodeType',
-                    'type=VanityUrl/field=findAvailableNodeName/arg=language',
-                    'type=GqlDashboard',
-                    'type=GqlModule',
-                    'type=EditorForm',
-                    'type=EditorFormSection',
-                    'type=EditorFormFieldSet',
-                    'type=EditorFormField',
-                    'type=EditorFormFieldValue',
-                    'type=EditorFormProperty',
-                    'type=EditorFormFieldValueConstraint',
-                    'type=GqlEditorForms',
-                    'type=GqlEditorForm',
-                    'type=GqlEditorFormSection',
-                    'type=GqlEditorFormFieldSet',
-                    'type=GqlEditorFormField',
-                    'type=GqlEditorFormFieldValue',
-                    'type=GqlEditorFormProperty',
-                    'type=GqlEditorFormFieldValueConstraint',
-                    'type=GqlEditorFormValue',
-                    'type=GqlEditorFormValueConstraint',
-                    'type=InputContextEntryInput',
-                    'inputType=InputContextEntryInput/field=key',
-                    'inputType=InputContextEntryInput/field=value',
-                    'type=Query/field=categoryById/arg=id',
-                    'type=Metadata/field=uuid',
-                    'type=Metadata/field=path',
-                    'type=Category/field=uuid',
-                    'type=Category/field=path',
-                    'type=Query/field=categoryByPath/arg=path',
-                    'type=GqlNpmHelper'
-                ];
-                noDescBlacklist.forEach(n => noDesc.delete(n));
+        // Missing but provided by:  https://github.com/Jahia/content-editor or https://github.com/Jahia/jcontent 
+        'GqlEditorForms',
+        'GqlEditorForm',
 
-                const invalidNameBlacklist = ['wipInfo'];
-                invalidNameBlacklist.forEach(n => invalidNames.delete(n));
+        // Missing but provided by: https://github.com/Jahia/jahia-dashboard
+        'GqlDashboard', 
 
-                expect(JSON.stringify(Array.from(noDesc))).to.equals('[]');
-                expect(JSON.stringify(Array.from(invalidNames))).to.equals('[]');
+        // Missing but provided by: https://github.com/Jahia/server-availability-manager
+        'AdminQuery/JahiaAdminQuery/healthCheck',
+        'AdminQuery/JahiaAdminQuery/GqlHealthCheck',
+        'AdminQuery/JahiaAdminQuery/Load',
+
+        // Missing but provided by: https://github.com/Jahia/security-filter-tools
+        'JWTToken',
+        'jwtToken',
+
+        // These are provided by graphql-dxm-provider
+        // Descriptions should be added via a separate ticket:
+        'Query/WorkflowService',
+        'Mutation/AdminMutation/JahiaAdminMutation/GqlConfigurationMutation',
+        'Mutation/JCRMutation',
+        'Mutation/WorkflowMutation',
+        'Mutation/mutateWorkflows',
+        'Subscription/GqlWorkflowEvent',
+    ];
+
+    const entryNodes = ['Query', 'Mutation', 'Subscription']
+    entryNodes.forEach((entryNode) => {
+        it(`Verify presence of a description all nodes under ${entryNode}`, () => {
+            getDescriptions(entryNode).then(result => {
+                console.log(result)
+    
+                // Get the list of nodes that are missing descriptions
+                // Remove the nodes that are in the blacklist
+                const noDesc = result
+                    .filter((graphqlType => graphqlType.description === null || graphqlType.description.length === 0))
+                    .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))))
+    
+                noDesc.forEach((graphqlType) => {
+                    cy.log('Missing description for node at path: ' + graphqlType.nodePath.join('/'))
+                    console.log('Missing description for type: ' + graphqlType.name + ' in path: ' + graphqlType.nodePath.join('/'), graphqlType)
+                })
+                cy.then(() => expect(noDesc.length).to.equal(0))
             });
+        });
     });
+
 });
-
-// Test to go down the AST of GraphQL to check for descriptions
-// eslint-disable-next-line max-params
-const executeTest = async (client, typeName, types, noDesc, invalidNames) => {
-    if (types.has(typeName)) {
-        return;
-    }
-
-    if (typeName[0] !== typeName[0].toUpperCase()) {
-        invalidNames.add(typeName);
-    }
-
-    types.add(typeName);
-
-    const query = constructQuery(typeName);
-    const response = await client.query({query});
-    const responseDataType = response.data.__type;
-    if (responseDataType === null || responseDataType === undefined || responseDataType.kind === 'UNION') {
-        return;
-    }
-
-    if (!responseDataType.description) {
-        noDesc.add('type=' + responseDataType.name);
-    }
-
-    if (responseDataType.fields) {
-        await asyncForEach(responseDataType.fields, async field => {
-            if (field.args) {
-                await asyncForEach(field.args, async arg => {
-                    await fieldCheck(
-                        client,
-                        'type=' + responseDataType.name + '/field=' + field.name + '/arg=' + arg.name,
-                        arg,
-                        types,
-                        noDesc,
-                        invalidNames
-                    );
-                });
-            }
-
-            await fieldCheck(
-                client,
-                'type=' + responseDataType.name + '/field=' + field.name,
-                field,
-                types,
-                noDesc,
-                invalidNames
-            );
-        });
-    }
-
-    if (responseDataType.inputFields) {
-        await asyncForEach(responseDataType.inputFields, async field => {
-            if (field.args) {
-                await asyncForEach(field.args, async arg => {
-                    await fieldCheck(
-                        client,
-                        'inputType=' + responseDataType.name + '/arg=' + arg.name,
-                        arg,
-                        types,
-                        noDesc,
-                        invalidNames
-                    );
-                });
-            }
-
-            await fieldCheck(
-                client,
-                'inputType=' + responseDataType.name + '/field=' + field.name,
-                field,
-                types,
-                noDesc,
-                invalidNames
-            );
-        });
-    }
-};
-
-// eslint-disable-next-line max-params
-const fieldCheck = async (client, message, field, types, noDesc, invalidNames) => {
-    if (field.description === null) {
-        noDesc.add(message);
-    }
-
-    let type = field.type;
-
-    while (type.ofType) {
-        type = type.ofType;
-    }
-
-    if (type.kind === 'OBJECT' || type.kind === 'INPUT_OBJECT') {
-        await executeTest(client, type.name, types, noDesc, invalidNames);
-    }
-};
-
-const asyncForEach = async (array, callback) => {
-    for (let index = 0; index < array.length; index++) {
-        // eslint-disable-next-line no-await-in-loop
-        await callback(array[index], index, array);
-    }
-};
-
-const constructQuery = typeName => {
-    return gql`query IntrospectionQuery {
-        __type(name:"${typeName}") {
-            kind
-            name
-            description
-            fields {
-                name
-                description
-                args {
-                    name
-                    description
-                    type {
-                        kind
-                        name
-                        description
-                        ofType {
-                            kind
-                            name
-                            description
-                        }
-                    }
-                }
-                type {
-                    kind
-                    name
-                    description
-                    ofType {
-                        kind
-                        name
-                        description
-                    }
-                }
-            }
-            inputFields {
-                name
-                description
-                type {
-                    kind
-                    name
-                    description
-                    ofType {
-                        kind
-                        name
-                        description
-                        ofType {
-                            kind
-                            name
-                        }
-                    }
-                }
-            }
-        }
-    }`;
-};

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -69,12 +69,12 @@ describe('Test for GraphQL schema description', () => {
 
                 // Get the list of nodes that are deprecated and ensure an explanation is present (deprecationReason)*
                 // "Deprecated" (in all its forms) is not considered a valid deprecationReason
-                // Remove the nodes that are in the blacklist 
+                // Remove the nodes that are in the blacklist
                 const noDeprecateReason = result
-                    .filter((graphqlType => (graphqlType.isDeprecated === true && (!graphqlType.deprecationReason || graphqlType.deprecationReason.length === 0 || (graphqlType.deprecationReason instanceof String && graphqlType.deprecationReason.toLowercase() === ("Deprecated").toLowerCase())))))
+                    .filter((graphqlType => (graphqlType.isDeprecated === true && (!graphqlType.deprecationReason || graphqlType.deprecationReason.length === 0 || (graphqlType.deprecationReason instanceof String && graphqlType.deprecationReason.toLowercase() === ('Deprecated').toLowerCase())))))
                     .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))));
 
-                    noDeprecateReason.forEach(description => {
+                noDeprecateReason.forEach(description => {
                     cy.log(`Deprecated ${description.schemaType} missing explanation at path: ${description.nodePath.join('/')}`);
                     console.log(`Deprecated ${description.schemaType} missing explanation at path: ${description.nodePath.join('/')}`);
                 });

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -1,3 +1,5 @@
+/* eslint max-nested-callbacks: ["error", 6] */
+
 import {getDescriptions} from '@jahia/cypress';
 
 describe('Test if every all nodes of the GraphQL schema have a description', () => {
@@ -5,14 +7,14 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
     // These descriptions should be added in their respective codebases
     const noDescBlacklist = [
         // Missing but provided by: https://github.com/Jahia/npm-modules-engine
-        'GqlNpmHelper', 
+        'GqlNpmHelper',
 
-        // Missing but provided by:  https://github.com/Jahia/content-editor or https://github.com/Jahia/jcontent 
+        // Missing but provided by:  https://github.com/Jahia/content-editor or https://github.com/Jahia/jcontent
         'GqlEditorForms',
         'GqlEditorForm',
 
         // Missing but provided by: https://github.com/Jahia/jahia-dashboard
-        'GqlDashboard', 
+        'GqlDashboard',
 
         // Missing but provided by: https://github.com/Jahia/server-availability-manager
         'AdminQuery/JahiaAdminQuery/healthCheck',
@@ -30,28 +32,27 @@ describe('Test if every all nodes of the GraphQL schema have a description', () 
         'Mutation/JCRMutation',
         'Mutation/WorkflowMutation',
         'Mutation/mutateWorkflows',
-        'Subscription/GqlWorkflowEvent',
+        'Subscription/GqlWorkflowEvent'
     ];
 
-    const entryNodes = ['Query', 'Mutation', 'Subscription']
-    entryNodes.forEach((entryNode) => {
+    const entryNodes = ['Query', 'Mutation', 'Subscription'];
+    entryNodes.forEach(entryNode => {
         it(`Verify presence of a description all nodes under ${entryNode}`, () => {
             getDescriptions(entryNode).then(result => {
-                console.log(result)
-    
+                console.log(result);
+
                 // Get the list of nodes that are missing descriptions
                 // Remove the nodes that are in the blacklist
                 const noDesc = result
                     .filter((graphqlType => graphqlType.description === null || graphqlType.description.length === 0))
-                    .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))))
-    
-                noDesc.forEach((graphqlType) => {
-                    cy.log('Missing description for node at path: ' + graphqlType.nodePath.join('/'))
-                    console.log('Missing description for type: ' + graphqlType.name + ' in path: ' + graphqlType.nodePath.join('/'), graphqlType)
-                })
-                cy.then(() => expect(noDesc.length).to.equal(0))
+                    .filter((graphqlType => !noDescBlacklist.some(t => graphqlType.nodePath.join('/').includes(t))));
+
+                noDesc.forEach(graphqlType => {
+                    cy.log('Missing description for node at path: ' + graphqlType.nodePath.join('/'));
+                    console.log('Missing description for type: ' + graphqlType.name + ' in path: ' + graphqlType.nodePath.join('/'), graphqlType);
+                });
+                cy.then(() => expect(noDesc.length).to.equal(0));
             });
         });
     });
-
 });

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -31,7 +31,7 @@ describe('Test for GraphQL schema description', () => {
 
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket: BACKLOG-22338
-        'JCRNode/findAvailableNodeName/',        
+        'JCRNode/findAvailableNodeName/',
         'InputFieldFiltersInput/multi/MulticriteriaEvaluation',
         'InputFieldSorterInput/sortType/SortType',
         'InputFieldGroupingInput/groupingType/GroupingType',

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -26,7 +26,7 @@ describe('Test for GraphQL schema description', () => {
         'jwtToken',
 
         // These are provided by graphql-dxm-provider
-        // Descriptions should be added via a separate ticket:
+        // Descriptions should be added via a separate ticket: BACKLOG-22338
         'Query/categoryById/id',
         'Query/categoryByPath/path',
         'findAvailableNodeName',

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -32,6 +32,8 @@ describe('Test for GraphQL schema description', () => {
         // These are provided by graphql-dxm-provider
         // Descriptions should be added via a separate ticket: BACKLOG-22338
         'findAvailableNodeName',
+        'categoryById/id',
+        'categoryByPath/path',
         'InputFieldFiltersInput/multi/MulticriteriaEvaluation',
         'InputFieldSorterInput/sortType/SortType',
         'InputFieldGroupingInput/groupingType/GroupingType',

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,7 @@
     "@cypress/code-coverage": "^3.9.11",
     "@cypress/webpack-preprocessor": "^5.9.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@jahia/cypress": "^3.17.9",
+    "@jahia/cypress": "3.18.1",
     "@jahia/eslint-config": "^2.1.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,7 @@
     "@cypress/code-coverage": "^3.9.11",
     "@cypress/webpack-preprocessor": "^5.9.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@jahia/cypress": "^3.17.2",
+    "@jahia/cypress": "^3.17.8",
     "@jahia/eslint-config": "^2.1.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,7 +7,7 @@
     "@cypress/code-coverage": "^3.9.11",
     "@cypress/webpack-preprocessor": "^5.9.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@jahia/cypress": "^3.17.8",
+    "@jahia/cypress": "^3.17.9",
     "@jahia/eslint-config": "^2.1.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1936,12 +1936,13 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/cypress@^3.17.2":
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.17.2.tgz#63663b4b4cf53d6cc7f4edff768201aa63c79ecc"
-  integrity sha512-F7nFVQuA3JfTUzemECT7f/WMC7PAqrrDrKAxy0F2zJGEpBJCH2qBBZq127MkSgH7FyJyzQgRdqyzyAdTz1Bmsw==
+"@jahia/cypress@^3.17.8":
+  version "3.17.8"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.17.8.tgz#7b4b5b9760334ba117c27db6151d31f5fed9c8a7"
+  integrity sha512-cNTFD2P5FTjoQQdOGQvYdoClUQoZN3V6J1BUzyVhSoVOjJHaX62QfXobpnXHVAlIniXpH0/IrX6GVwaeobZ3Pg==
   dependencies:
     "@apollo/client" "^3.4.9"
+    cypress-real-events "^1.11.0"
     graphql "^15.5.0"
     graphql-tag "^2.11.0"
 
@@ -3880,6 +3881,11 @@ cypress-multi-reporters@^1.6.3:
   dependencies:
     debug "^4.3.4"
     lodash "^4.17.21"
+
+cypress-real-events@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.11.0.tgz#292fe5281c5b6e955524e766ab7fec46930c7763"
+  integrity sha512-4LXVRsyq+xBh5TmlEyO1ojtBXtN7xw720Pwb9rEE9rkJuXmeH3VyoR1GGayMGr+Itqf11eEjfDewtDmcx6PWPQ==
 
 cypress-terminal-report@^5.3.7:
   version "5.3.7"

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1936,10 +1936,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/cypress@^3.17.8":
-  version "3.17.8"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.17.8.tgz#7b4b5b9760334ba117c27db6151d31f5fed9c8a7"
-  integrity sha512-cNTFD2P5FTjoQQdOGQvYdoClUQoZN3V6J1BUzyVhSoVOjJHaX62QfXobpnXHVAlIniXpH0/IrX6GVwaeobZ3Pg==
+"@jahia/cypress@^3.17.9":
+  version "3.17.9"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.17.9.tgz#b18d3a0bae8855afce77f09176d8c086d6148111"
+  integrity sha512-K4ZvC8b9PfI9/HH4DBGu4TAdO26embE8GAkIEkd0QqR9xONBfQRgBiYf6I6IHoj9InYFSYeG7gSJrng5NzoH6A==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -1936,11 +1936,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/cypress@^3.17.9":
-  version "3.17.9"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.17.9.tgz#b18d3a0bae8855afce77f09176d8c086d6148111"
-  integrity sha512-K4ZvC8b9PfI9/HH4DBGu4TAdO26embE8GAkIEkd0QqR9xONBfQRgBiYf6I6IHoj9InYFSYeG7gSJrng5NzoH6A==
-
+"@jahia/cypress@3.18.1":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.18.1.tgz#b7445bce781b1c4603ecdcb8b6c33795933d6796"
+  integrity sha512-QnPAONPHiVzk9RknjFAdBDNUuQtqln0dceNogXJ/rLdXYNlul4/wQiVsOYN+PueZ7+dVM8hKd1mTF3zt1Sxr1Q==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
Some nodes were missing in the previous implementation. The logic of fetching descriptions was moved to jahia-cypress.

This new test suite also verified the presence of deprecation messages.