### PR TITLE
QA-15096: Enforce limit of 5000 nodes for one page. Log messages over 500 (#401)

### DIFF
--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -33,3 +33,4 @@
 # List of allowed origin for CORS access :
 #
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
+graphql.fields.node.limit = 5000


### PR DESCRIPTION
* QA-15096: Enforce limit of 5000 nodes for one page. Log messages over 500

* QA-15096: Add stack trace and use an AtomicInteger for node limit

* QA-15096: Ensure node limit can be set only on default file

(cherry picked from commit 9ec98610993e731378fee1ee737b4e6073f35485)

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/ QA-15096

## Description

Port from 2_x


