### PR TITLE
BACKLOG-22395: Remove unused jsp elvariable declaration to fix MANIFEST

### DIFF
--- a/graphql-dxm-provider/src/main/resources/tools/developer/sdlreporttool.jsp
+++ b/graphql-dxm-provider/src/main/resources/tools/developer/sdlreporttool.jsp
@@ -8,7 +8,6 @@
 <%@ taglib prefix="graphql" uri="http://www.jahia.org/graphql-dxm-provider/functions" %>
 <%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
-<%--@elvariable id="flowRequestContext" type="org.springframework.webflow.execution.RequestContext"--%>
 <%--@elvariable id="out" type="java.io.PrintWriter"--%>
 <%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
 <%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-22395

## Description

As mentionned in the ticket a strang import fo sping webflow packages has been detected and it was due to a elvariable declaration in a jsp. After removing that declaration (it was not used) the Import is not present anymore in MANIFEST neither in the OSGI wiring (inspected using tool)

## Tests

The following are included in this PR

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

N/A