### PR TITLE
Disable dependabot PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,16 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "daily"
     allow:
       - dependency-type: "production"
   - package-ecosystem: "maven"
+    # Disable version updates for maven dependencies
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

We don't want the bot to create PR anymore