### PR TITLE
BACKLOG-21149: Fix release issue by switching to a version constant

### DIFF
--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>${parent.version}</version>
+            <version>3.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21149

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Failing dry-run test when releasing graphql-core https://github.com/Jahia/JahiaReleaseTool/actions/runs/8633445632/job/23668506436#step:8:9511: 

```
2024-04-10T15:56:51.4734773Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3-jahia1:prepare (default-cli) on project graphql-core-root: The version could not be updated: ${parent.version} -> [Help 1]
2024-04-10T15:56:51.4742650Z org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3-jahia1:prepare (default-cli) on project graphql-core-root: The version could not be updated: ${parent.version}
```

mvn needs to be able to convert to release version. Use a constant version instead.