### PR TITLE
BACKLOG-22906: Fix issue when uninstalling bundle and exception cause is null

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -270,7 +270,8 @@ public class DXGraphQLProvider implements
                     }
                 }
             } catch (Throwable e) {
-                logger.error("Unable to register extension for provider {} because {}", extensionsProvider.getClass().getName(), e.getCause().toString());
+                logger.error("Unable to register extension for provider {} because {}", extensionsProvider.getClass().getName(),
+                        (e.getCause() != null)?e.getCause().toString():"Cause is null");
                 logger.debug("full error", e);
             }
         }


### PR DESCRIPTION
## JIRA

## Description

When an exception raise, there is a NPE on the getCause() when null.

