### PR TITLE
BACKLOG-23059 Allow site admin to unlock nodes locked by other users

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclEntry.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclEntry.java
@@ -23,6 +23,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.acl.service;
 
+import org.jahia.modules.graphql.provider.dxm.user.PrincipalType;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.decorator.JCRSiteNode;
 import org.slf4j.Logger;
@@ -127,6 +128,18 @@ public class JahiaAclEntry {
 
     public boolean isDenyType() {
         return type == AclEntryType.DENY;
+    }
+
+    public boolean isUserPrincipal() {
+        return PrincipalType.isUser(principalKey);
+    }
+
+    public boolean isGroupPrincipal() {
+        return PrincipalType.isGroup(principalKey);
+    }
+
+    public String getPrincipalName() {
+        return principalKey.substring(2);
     }
 
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
@@ -23,6 +23,7 @@ package org.jahia.modules.graphql.provider.dxm.acl.service;/*
  */
 
 import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.usermanager.JahiaUser;
 
 import javax.jcr.RepositoryException;
 import java.util.List;
@@ -71,6 +72,8 @@ public interface JahiaAclService {
      * @return true if principalKey has GRANT permission on a roleName for a given node; false otherwise.
      */
     public boolean hasInheritedPermission(JCRNodeWrapper node, String principalKey, String roleName);
+
+    public boolean hasInheritedUserRole(JCRNodeWrapper node, JahiaUser user, String roleName) throws RepositoryException;
 
     public List<JahiaAclEntry> getAclEntries(JCRNodeWrapper jcrNode);
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclService.java
@@ -73,6 +73,9 @@ public interface JahiaAclService {
      */
     public boolean hasInheritedPermission(JCRNodeWrapper node, String principalKey, String roleName);
 
+    /**
+     * @return true if user has a role on a given node or belongs to a group who has role on a given node
+     */
     public boolean hasInheritedUserRole(JCRNodeWrapper node, JahiaUser user, String roleName) throws RepositoryException;
 
     public List<JahiaAclEntry> getAclEntries(JCRNodeWrapper jcrNode);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
@@ -30,6 +30,7 @@ import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.decorator.JCRSiteNode;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
+import org.jahia.services.usermanager.JahiaUser;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -119,6 +120,25 @@ public class JahiaAclServiceImpl implements JahiaAclService {
     public boolean hasInheritedPermission(JCRNodeWrapper jcrNode, String principalKey, String roleName) {
         List<JahiaAclEntry> aclEntries = getAclEntries(jcrNode, principalKey);
         return aclEntries.stream().anyMatch(ace -> roleName.equals(ace.getRoleName()) && ace.isGrantType() && ace.isInherited());
+    }
+
+    public boolean hasInheritedUserRole(JCRNodeWrapper node, JahiaUser user, String roleName) throws RepositoryException {
+        List<JahiaAclEntry> aclEntries = this.getAclEntries(node);
+        JCRSiteNode site = node.getResolveSite();
+        return aclEntries
+                .stream()
+                .anyMatch(ace -> {
+                    if (!ace.isGrantType()) return false;
+                    if (ace.getRoleName().equalsIgnoreCase(roleName)) {
+                        if (ace.getPrincipalKey().startsWith("u:") && ace.getPrincipalKey().substring(2).equalsIgnoreCase(user.getUsername())) {
+                            return true;
+                        }
+                        if (ace.getPrincipalKey().startsWith("g:") && this.groupService.isMember(user.getUsername(), ace.getPrincipalKey().substring(2), site.getSiteKey())) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
     }
 
     public List<JahiaAclEntry> getAclEntries(JCRNodeWrapper jcrNode, String principalKey) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/acl/service/JahiaAclServiceImpl.java
@@ -130,10 +130,10 @@ public class JahiaAclServiceImpl implements JahiaAclService {
                 .anyMatch(ace -> {
                     if (!ace.isGrantType()) return false;
                     if (ace.getRoleName().equalsIgnoreCase(roleName)) {
-                        if (ace.getPrincipalKey().startsWith("u:") && ace.getPrincipalKey().substring(2).equalsIgnoreCase(user.getUsername())) {
+                        if (ace.isUserPrincipal() && ace.getPrincipalName().equalsIgnoreCase(user.getUsername())) {
                             return true;
                         }
-                        if (ace.getPrincipalKey().startsWith("g:") && this.groupService.isMember(user.getUsername(), ace.getPrincipalKey().substring(2), site.getSiteKey())) {
+                        if (ace.isGroupPrincipal() && this.groupService.isMember(user.getUsername(), ace.getPrincipalName(), site.getSiteKey())) {
                             return true;
                         }
                     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/locking/GqlLockInfo.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/locking/GqlLockInfo.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang.StringUtils;
 import org.jahia.modules.graphql.provider.dxm.acl.service.JahiaAclService;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
 import org.jahia.services.content.JCRNodeWrapper;
-import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,10 +46,6 @@ public class GqlLockInfo {
     @Inject
     @GraphQLOsgiService
     private JahiaAclService aclService;
-
-    @Inject
-    @GraphQLOsgiService
-    private JahiaGroupManagerService groupManagerService;
 
     @GraphQLField
     @GraphQLDescription("Is node lockable")

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/locking/LockJCRNodeMutationExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/locking/LockJCRNodeMutationExtension.java
@@ -26,7 +26,6 @@ import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.usermanager.JahiaUser;
 
-import javax.inject.Inject;
 import javax.jcr.RepositoryException;
 import java.util.function.Supplier;
 
@@ -36,20 +35,19 @@ import java.util.function.Supplier;
 @GraphQLTypeExtension(GqlJcrNodeMutation.class)
 public class LockJCRNodeMutationExtension {
 
-    private GqlJcrNodeMutation nodeMutation;
+    private final GqlJcrNodeMutation nodeMutation;
+    private final JahiaAclService aclService;
 
     /**
      * Create a lock mutation extension instance.
      *
      * @param nodeMutation JCR node mutation to apply the extension to
      */
-    @Inject
     public LockJCRNodeMutationExtension(GqlJcrNodeMutation nodeMutation) {
         this.nodeMutation = nodeMutation;
         this.aclService = BundleUtils.getOsgiService(JahiaAclService.class, null);
     }
 
-    private JahiaAclService aclService;
 
     /**
      * Lock the node.

--- a/tests/cypress/e2e/api/jcr/locks.cy.ts
+++ b/tests/cypress/e2e/api/jcr/locks.cy.ts
@@ -54,7 +54,6 @@ describe('Node locks tests', () => {
                 }
             })
             .should(resp => {
-                debugger;
                 expect(resp?.data?.jcr?.nodeByPath?.lockInfo?.canUnlock, 'Cannot unlock').to.be.false;
             });
 

--- a/tests/cypress/e2e/api/jcr/locks.cy.ts
+++ b/tests/cypress/e2e/api/jcr/locks.cy.ts
@@ -1,0 +1,99 @@
+import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
+import {grantUserRole} from '../../../fixtures/acl';
+
+describe('Node locks tests', () => {
+    const siteName = 'locks';
+    const sitePath = '/sites/locks';
+    const page1Path = sitePath + '/home/page1';
+    const page2Path = sitePath + '/home/page2';
+    const siteAdminCredentials = {username: 'bill', password: 'password'};
+    const editorCredentials = {username: 'mathias', password: 'password'};
+
+    before('Create a site', () => {
+        createSite(siteName);
+        addNode({
+            parentPathOrId: sitePath + '/home',
+            name: 'page1',
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'page1'},
+                {name: 'j:templateName', value: 'simple'}
+            ]
+        });
+        addNode({
+            parentPathOrId: sitePath + '/home',
+            name: 'page2',
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'page2'},
+                {name: 'j:templateName', value: 'simple'}
+            ]
+        });
+        publishAndWaitJobEnding(sitePath, ['en']);
+        grantUserRole(sitePath, 'site-administrator', 'bill');
+        grantUserRole(sitePath, 'editor', 'mathias');
+    });
+
+    after('Delete the site', () => {
+        deleteSite(siteName);
+    });
+
+    it('Should not let user unlock a node that is locked by another user', () => {
+        cy.apolloClient(siteAdminCredentials).apollo({
+            queryFile: 'jcr/lockNode.graphql',
+            variables: {
+                pathOrId: page1Path
+            }
+        });
+
+        cy.apolloClient(editorCredentials)
+            .apollo({
+                queryFile: 'jcr/lockInfoByPath.graphql',
+                variables: {
+                    pathOrId: page1Path
+                }
+            })
+            .should(resp => {
+                debugger;
+                expect(resp?.data?.jcr?.nodeByPath?.lockInfo?.canUnlock, 'Cannot unlock').to.be.false;
+            });
+
+        cy.apolloClient(editorCredentials)
+            .apollo({
+                queryFile: 'jcr/unlockNode.graphql',
+                variables: {pathOrId: page1Path}
+            })
+            .should(resp => {
+                expect(resp?.data?.jcr?.mutateNode?.unlock, 'Unlock request KO').to.be.false;
+            });
+    });
+
+    it('Should let site admins unlock content locked by another user', () => {
+        cy.apolloClient(editorCredentials).apollo({
+            queryFile: 'jcr/lockNode.graphql',
+            variables: {
+                pathOrId: page2Path
+            }
+        });
+
+        cy.apolloClient(siteAdminCredentials)
+            .apollo({
+                queryFile: 'jcr/lockInfoByPath.graphql',
+                variables: {
+                    pathOrId: page2Path
+                }
+            })
+            .should(resp => {
+                expect(resp?.data?.jcr?.nodeByPath?.lockInfo?.canUnlock, 'Can unlock').to.be.true;
+            });
+
+        cy.apolloClient(siteAdminCredentials)
+            .apollo({
+                queryFile: 'jcr/unlockNode.graphql',
+                variables: {pathOrId: page2Path}
+            })
+            .should(resp => {
+                expect(resp?.data?.jcr?.mutateNode?.unlock, 'Unlock request OK').to.be.true;
+            });
+    });
+});

--- a/tests/cypress/fixtures/jcr/lockInfoByPath.graphql
+++ b/tests/cypress/fixtures/jcr/lockInfoByPath.graphql
@@ -1,0 +1,10 @@
+query lockInfoByPath($pathOrId: String!) {
+    jcr {
+        nodeByPath(path: $pathOrId) {
+            lockInfo {
+                canLock
+                canUnlock
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/jcr/lockNode.graphql
+++ b/tests/cypress/fixtures/jcr/lockNode.graphql
@@ -1,0 +1,7 @@
+mutation lockNode($pathOrId: String!) {
+    jcr(workspace: EDIT) {
+        mutateNode(pathOrId: $pathOrId) {
+            lock
+        }
+    }
+}

--- a/tests/cypress/fixtures/jcr/unlockNode.graphql
+++ b/tests/cypress/fixtures/jcr/unlockNode.graphql
@@ -1,0 +1,7 @@
+mutation lockNode($pathOrId: String!) {
+    jcr(workspace: EDIT) {
+        mutateNode(pathOrId: $pathOrId) {
+            unlock
+        }
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23059

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This PR modifies the locking api, to allow site admins to unlock stuff locked by regular users. It also fixes a bug in the lockInfo node.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
