### PR TITLE
BACKLOG-23110: fix provisioning

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -32,7 +32,6 @@
 
 - installBundle:
   - 'mvn:org.jahia.modules/graphql-dxm-provider'
-  - 'mvn:org.jahia.test/graphql-test'
   - 'mvn:org.jahia.modules/graphql-extension-example'
   autoStart: true
   uninstallPreviousVersion: true

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -32,7 +32,7 @@
 
 - installBundle:
   - 'mvn:org.jahia.modules/graphql-dxm-provider'
-  - 'mvn:org.jahia.test/graphql-test-module'
+  - 'mvn:org.jahia.test/graphql-test'
   - 'mvn:org.jahia.modules/graphql-extension-example'
   autoStart: true
   uninstallPreviousVersion: true


### PR DESCRIPTION
## Description

Latest nightly failed because we could not install mvn:org.jahia.test/graphql-test-module.
I could not find it but I found mvn:org.jahia.test/**graphql-test** so I replaced it in the provisioning.
Update: I removed it from provisioning because the tests are green on release so the module doesn't seem to be necessary.