### PR TITLE
SEC-104: Fix SDL extensions test

### DIFF
--- a/tests/cypress/e2e/sdl/sdlExtensions.cy.js
+++ b/tests/cypress/e2e/sdl/sdlExtensions.cy.js
@@ -1,32 +1,30 @@
-import {
-    getCoreSdlExtensions,
-    getExampleSdlExtensions
-} from '../../fixtures/sdl/sdlExtensions';
+import {getTypeFields} from '../../fixtures/sdl/sdlExtensions';
 
 describe('SDL extensions', () => {
+
+    function verifySdlFields(typeName, expectedFields) {
+        return cy.apollo({query: getTypeFields(typeName)})
+            .then((response) => {
+                const data = response?.data || {};
+                const fieldNames = data['__type']?.fields?.map(f => f.name) || [];
+                if (expectedFields) {
+                    expect(fieldNames).to.deep.eq(expectedFields);
+                }
+                return fieldNames;
+            });
+    }
+
     it('should have SDL extensions defined in dxm-provider module', () => {
-        cy.apollo({query: getCoreSdlExtensions}).then((response) => {
-            const {category, imageAsset} = response?.data || {};
-            expect(category?.fields?.map(f => f.name)).to.deep.eq(
-                ['metadata', 'description', 'title']
-            );
-            expect(imageAsset?.fields?.map(f => f.name)).to.deep.eq(
-                ['metadata', 'type', 'size', 'height', 'width']
-            );
-        });
+        verifySdlFields('Category', ['metadata', 'description', 'title']);
+        verifySdlFields('ImageAsset', ['metadata', 'type', 'size', 'height', 'width']);
     });
 
     it('should have SDL extensions defined in extension-examples module', () => {
-        cy.apollo({query: getExampleSdlExtensions}).then((response) => {
-            const {newsSdl, images, queries} = response?.data || {};
-            expect(newsSdl?.fields?.map(f => f.name)).to.deep.eq(
-                ['title', 'description', 'checked', 'date']
-            );
-            expect(images?.fields?.map(f => f.name)).to.deep.eq(
-                ['height']
-            );
+        verifySdlFields('NewsSDL', ['title', 'description', 'checked', 'date']);
+        verifySdlFields('Images', ['height']);
+        verifySdlFields('Query').then(returnedFields => {
             ['newsByChecked', 'myNewsByDate', 'myImagesByHeight'].forEach(queryField => {
-                expect(queries?.fields?.find(f => f.name === queryField)).to.exist;
+                expect(returnedFields).to.include(queryField);
             });
         });
     });

--- a/tests/cypress/fixtures/sdl/sdlExtensions.js
+++ b/tests/cypress/fixtures/sdl/sdlExtensions.js
@@ -1,25 +1,8 @@
 import gql from 'graphql-tag';
 
-export const getCoreSdlExtensions = gql`
+export const getTypeFields = (typeName) => gql`
     query coreSdlExtensions {
-        category: __type(name: "Category") {
-            fields {name}
-        },
-        imageAsset: __type(name: "ImageAsset") {
-            fields {name}
-        }
-    }
-`;
-
-export const getExampleSdlExtensions = gql`
-    query exampleSdlExtensions {
-        newsSdl: __type(name:"NewsSDL") {
-            fields {name}
-        }
-        images: __type(name:"Images") {
-            fields {name}
-        }
-        queries: __type(name: "Query") {
+        __type(name: "${typeName}") {
             fields {name}
         }
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SEC-104

## Description 

Due to graphql-java 21.5 update https://github.com/Jahia/jahia-private/pull/2141, introspection queries are now limited to only one per query ([link](https://github.com/graphql-java/graphql-java/blob/96cadf7dc67b7905f7e960ee31e00a8373639423/src/main/java/graphql/introspection/GoodFaithIntrospection.java#L79)) otherwise it returns the error:

```
{
  "errors": [
    {
      "message": "This request is not asking for introspection in good faith - __Type.fields is present too often!",
      "extensions": {
        "classification": "BadFaithIntrospection"
      }
    }
  ],
  "data": null
}
```

Refactor test to query `__type` fields one at a time.