### PR TITLE
SEC-104: Disable introspection queries in production

### DIFF
--- a/graphql-dxm-provider/package.json
+++ b/graphql-dxm-provider/package.json
@@ -27,6 +27,9 @@
   "jahia": {
     "remotes": {
       "jahia": "javascript/apps/remoteEntry.js"
+    },
+    "apps": {
+      "jahia": "configs/graphqlDxmProvider.jsp"
     }
   },
   "dependencies": {

--- a/graphql-dxm-provider/src/javascript/registrations/playground/registerRoutes.jsx
+++ b/graphql-dxm-provider/src/javascript/registrations/playground/registerRoutes.jsx
@@ -51,12 +51,14 @@ const GraphiQLComponent = () => {
 };
 
 export const registerRoutes = () => {
-    registry.add('adminRoute', 'graphql-workspace', {
-        targets: ['developerTools:20'],
-        requiredPermission: 'developerToolsAccess',
-        icon: window.jahia.moonstone.toIconComponent('GraphQl'),
-        label: 'graphql-dxm-provider:graphql',
-        isSelectable: true,
-        render: () => <GraphiQLComponent/>
-    });
+    if (window?.contextJsParameters?.config?.graphqlDxmProvider?.isIntrospectionEnabled) {
+        registry.add('adminRoute', 'graphql-workspace', {
+            targets: ['developerTools:20'],
+            requiredPermission: 'developerToolsAccess',
+            icon: window.jahia.moonstone.toIconComponent('GraphQl'),
+            label: 'graphql-dxm-provider:graphql',
+            isSelectable: true,
+            render: () => <GraphiQLComponent/>
+        });
+    }
 };

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/DXGraphQLProvider.java
@@ -25,6 +25,7 @@ import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.kickstart.servlet.osgi.*;
 import graphql.schema.*;
+import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility;
 import org.jahia.bin.filters.jcr.JcrSessionFilter;
 import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.jahia.modules.graphql.provider.dxm.node.*;
@@ -266,7 +267,11 @@ public class DXGraphQLProvider implements GraphQLTypesProvider, GraphQLQueryProv
         queryType = (GraphQLObjectType) graphQLAnnotations.getOutputTypeProcessor().getOutputTypeOrRef(Query.class, container);
         mutationType = (GraphQLObjectType) graphQLAnnotations.getOutputTypeProcessor().getOutputTypeOrRef(Mutation.class, container);
         subscriptionType = (GraphQLObjectType) graphQLAnnotations.getOutputTypeProcessor().getOutputTypeOrRef(Subscription.class, container);
-        codeRegistry = container.getCodeRegistryBuilder().build();
+        GraphQLCodeRegistry.Builder registryBuilder = container.getCodeRegistryBuilder();
+        if (!dxGraphQLConfig.isIntrospectionEnabled()) {
+            registryBuilder.fieldVisibility(NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY);
+        }
+        codeRegistry = registryBuilder.build();
         for (DXGraphQLExtensionsProvider extensionsProvider : extensionsProviders) {
             for (Class<?> aClass : extensionsProvider.getExtensions()) {
                 if (aClass.isAnnotationPresent(GraphQLTypeExtension.class)) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
@@ -142,8 +142,7 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
     }
 
     public boolean isIntrospectionEnabled() {
-        return false;
-//        return SettingsBean.getInstance().isDevelopmentMode() || introspectionEnabled;
+        return SettingsBean.getInstance().isDevelopmentMode() || introspectionEnabled;
     }
 
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
@@ -52,7 +52,7 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
     private Map<String, Set<String>> corsOriginByPid = new HashMap<>();
 
     private int nodeLimit = 5000;
-    private boolean introspectionEnabled = false;
+    private Boolean introspectionEnabled;
 
     private ComponentContext componentContext;
 
@@ -77,6 +77,14 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         Enumeration<String> keys = properties.keys();
         boolean isDefaultConfig = properties.get("felix.fileinstall.filename") != null &&
                 properties.get("felix.fileinstall.filename").toString().endsWith("org.jahia.modules.graphql.provider-default.cfg");
+
+        /*
+         * Keep track of ENABLE_INTROSPECTION_MODE property if it's defined or not (using null) in the default configuration
+         * and only set it to a true/false value if it's defined in the configuration file
+         */
+        if (isDefaultConfig) {
+            introspectionEnabled = null;
+        }
 
         while (keys.hasMoreElements()) {
             String key = keys.nextElement();
@@ -141,10 +149,13 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         }
     }
 
+    /**
+     * @return true if ENABLE_INTROSPECTION_MODE property is set to true for the default configuration, or false for any other value.
+     * It will be enabled in development mode by default, and disabled in production mode by default if the property is not defined.
+     */
     public boolean isIntrospectionEnabled() {
-        return SettingsBean.getInstance().isDevelopmentMode() || introspectionEnabled;
+        return (introspectionEnabled == null && SettingsBean.getInstance().isDevelopmentMode()) || introspectionEnabled;
     }
-
 
     public Map<String, String> getPermissions() {
         return permissions;

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
@@ -154,7 +154,10 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
      * It will be enabled in development mode by default, and disabled in production mode by default if the property is not defined.
      */
     public boolean isIntrospectionEnabled() {
-        return (introspectionEnabled == null && SettingsBean.getInstance().isDevelopmentMode()) || introspectionEnabled;
+        if (introspectionEnabled == null) {
+            return SettingsBean.getInstance().isDevelopmentMode();
+        }
+        return introspectionEnabled;
     }
 
     public Map<String, String> getPermissions() {

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -35,5 +35,6 @@
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
 graphql.fields.node.limit = 5000
 
-# Introspection queries are now disabled by default for production; Enable them by setting this property to true
+# Enable introspection queries in the graphql schema when set to true only in the default configuration file.
+# Introspection queries are enabled by default for development mode, and disabled by default in production mode.
 # graphql.introspection.enabled = false

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -34,3 +34,6 @@
 #
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
 graphql.fields.node.limit = 5000
+
+# Introspection queries are now disabled by default for production; Enable them by setting this property to true
+# graphql.introspection.enabled = false

--- a/graphql-dxm-provider/src/main/resources/configs/graphqlDxmProvider.jsp
+++ b/graphql-dxm-provider/src/main/resources/configs/graphqlDxmProvider.jsp
@@ -1,0 +1,10 @@
+<%@ page import="org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig"%>
+<%@ page import="org.jahia.osgi.BundleUtils"%>
+
+<%
+    DXGraphQLConfig gqlConfig = BundleUtils.getOsgiService(DXGraphQLConfig.class, null);
+%>
+
+contextJsParameters.config.graphqlDxmProvider = {
+    isIntrospectionEnabled: <%=gqlConfig.isIntrospectionEnabled()%>
+};

--- a/graphql-dxm-provider/src/main/resources/tools/graphql-workspace.jsp
+++ b/graphql-dxm-provider/src/main/resources/tools/graphql-workspace.jsp
@@ -1,14 +1,33 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="sql" uri="http://java.sun.com/jsp/jstl/sql" %>
+<%@ page import="org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig"%>
+<%@ page import="org.jahia.osgi.BundleUtils"%>
+
+<%
+    DXGraphQLConfig gqlConfig = BundleUtils.getOsgiService(DXGraphQLConfig.class, null);
+    pageContext.setAttribute("enableSandbox", gqlConfig.isIntrospectionEnabled());
+%>
 <script type="module"
         src="<c:url value='/modules/graphql-dxm-provider/javascript/tools/toolsembed.graphqldxm.bundle.js'/>"></script>
 <body>
 <div id="embedded-sandbox">
+    <c:if test="${not enableSandbox}">
+        <div role="alert">
+            GraphQL playground is not available due to introspection being currently disabled. To enable introspection for production, set
+            the property <code>graphql.introspection.enabled</code> to <code>true</code> in your
+            <code>org.jahia.modules.graphql.provider-default.cfg</code> configuration file.
+        </div>
+    </c:if>
 </div>
 </body>
+
 <script>
-    console.log('starting');
-    document.addEventListener("DOMContentLoaded",() => {
-        console.log('dom loaded');
-        GraphqlPlayground.EmbeddedSandbox('embedded-sandbox');
-    });
+    console.log('enable graphql sandbox: ${enableSandbox}');
+    <c:if test="${enableSandbox}">
+        document.addEventListener("DOMContentLoaded",() => {
+            console.log('dom loaded');
+            GraphqlPlayground.EmbeddedSandbox('embedded-sandbox');
+        });
+    </c:if>
 </script>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SEC-104

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Disable introspection queries and graphql playground (both in developer tools and jahia tools) in production (still enabled in dev mode by default)
- Add config entry `graphql.introspection.enabled` to enable and disable for both dev and prod modes.