### PR TITLE
QA-15174 Added default logic for rendering nodes

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
@@ -112,7 +112,7 @@ public class RenderNodeExtensions {
 
     @GraphQLField
     @GraphQLDescription("Gets the fully rendered content for this node")
-    public RenderedNode getRenderedContent(@GraphQLName("view") @GraphQLDescription("Name of the view") String view,
+    public RenderedNode getRenderedContent(@GraphQLName("view") @GraphQLDescription("Name of the view (leave null for default)") String view,
                                            @GraphQLName("templateType") @GraphQLDescription("Template type") String templateType,
                                            @GraphQLName("contextConfiguration") @GraphQLDescription("Rendering context configuration") String contextConfiguration,
                                            @GraphQLName("language") @GraphQLDescription("Language") String language,
@@ -151,6 +151,11 @@ public class RenderNodeExtensions {
             }
 
             JCRNodeWrapper node = NodeHelper.getNodeInLanguage(this.node.getNode(), language);
+
+            if (view == null) {
+                String definedView = node.hasProperty("j:view") ? node.getPropertyAsString("j:view") : null;
+                view = definedView != null && !definedView.isEmpty() ? definedView : "cm";
+            }
 
             Resource r = new Resource(node, templateType, view, contextConfiguration);
 

--- a/tests/cypress/e2e/api/graphqlRenderTest.cy.ts
+++ b/tests/cypress/e2e/api/graphqlRenderTest.cy.ts
@@ -327,4 +327,31 @@ describe('Test graphql rendering', () => {
         });
         deleteNode('/sites/' + sitename + '/home/news5');
     });
+
+    it('gets view name from property when rendering', () => {
+        addNode({
+            parentPathOrId: '/sites/' + sitename + '/home',
+            name: 'text1',
+            primaryNodeType: 'jnt:bigText',
+            properties: [
+                {name: 'text', language: 'en', value: 'test'},
+                {name: 'j:view', language: 'en', value: 'link'}
+            ],
+            mixins: ['jmix:renderable']
+        });
+
+        cy.apollo({
+            queryFile: 'jcr/nodeRenderedContent.graphql',
+            variables: {
+                path: '/sites/' + sitename + '/home/text1',
+                view: null
+            }
+        }).should(result => {
+            const output = result?.data?.jcr?.nodeByPath?.renderedContent.output;
+            expect(output).contains(
+                '<a target="" href="/cms/render/default/en/sites/graphql_test_render/home/text1.html">text1</a>'
+            );
+        });
+        deleteNode('/sites/' + sitename + '/home/text1');
+    });
 });

--- a/tests/cypress/fixtures/jcr/nodeRenderedContent.graphql
+++ b/tests/cypress/fixtures/jcr/nodeRenderedContent.graphql
@@ -1,4 +1,4 @@
-query($path: String!, $view: String!) {
+query($path: String!, $view: String) {
     jcr {
         nodeByPath(path: $path) {
             renderedContent(view: $view) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15174

## Description

This PR adds default logic to getting the rendered content of a node. If no view is supplied, the one from `j:view` property is used. If not present, the `cm` view is used.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
