### PR TITLE
QA-15289: GraphQL JCRSite query with restricted home page

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/site/GqlJcrSite.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/site/GqlJcrSite.java
@@ -110,9 +110,10 @@ public class GqlJcrSite extends GqlJcrNodeImpl implements GqlJcrNode {
 
     @GraphQLField
     @GraphQLName("homePage")
-    @GraphQLDescription("Returns the node of the home page")
+    @GraphQLDescription("Returns the node of the home page or null if no home page is defined or is not accessible")
     public GqlJcrNode getHomePage() throws RepositoryException {
-        return SpecializedTypesHandler.getNode(siteNode.getHome());
+        JCRNodeWrapper home = siteNode.getHome();
+        return home == null ? null : SpecializedTypesHandler.getNode(home);
     }
 
 }

--- a/tests/cypress/e2e/api/site.cy.ts
+++ b/tests/cypress/e2e/api/site.cy.ts
@@ -1,0 +1,76 @@
+import {addNode, createSite, createUser, deleteSite, deleteUser} from '@jahia/cypress';
+import {grantUserRole} from '../../fixtures/acl';
+
+describe('Test graphql site queries', () => {
+    const siteName = 'graphqlSite';
+    const username = 'testUser';
+    const password = 'password';
+
+    beforeEach('create test site and test user and grant editor role to the user on the site', () => {
+        createSite(siteName);
+        createUser(username, password);
+        grantUserRole('/sites/' + siteName, 'editor', username);
+    });
+
+    afterEach('Remove test data', () => {
+        deleteSite(siteName);
+        deleteUser(username);
+    });
+
+    it('Should be able to read the homePage property when requested as root', () => {
+        cy.apollo({
+            queryFile: 'site/getAllSitesWithHomePage.graphql'
+        }).should(result => {
+            const site = getSite(result, siteName);
+            expect(site).to.have.property('name', siteName);
+            expect(site).to.have.property('site');
+            expect(site.site).to.have.property('homePage');
+            expect(site.site.homePage).to.have.property('name', 'home');
+            expect(site.site.homePage).to.have.property('path', `/sites/${siteName}/home`);
+        });
+    });
+
+    it('Should be able to read the homePage property when requested as authorized user (editor)', () => {
+        cy
+            .apolloClient({username: username, password: password})
+            .apollo({
+                queryFile: 'site/getAllSitesWithHomePage.graphql'
+            }).should(result => {
+                const site = getSite(result, siteName);
+                expect(site).to.have.property('name', siteName);
+                expect(site).to.have.property('site');
+                expect(site.site).to.have.property('homePage');
+                expect(site.site.homePage).to.have.property('name', 'home');
+                expect(site.site.homePage).to.have.property('path', `/sites/${siteName}/home`);
+            });
+    });
+
+    it('Should not be able to see the homePage field when requested by an unauthorized user', () => {
+        // Disable the ACL inheritance on the home page
+        addNode({
+            parentPathOrId: '/sites/' + siteName + '/home',
+            name: 'j:acl',
+            primaryNodeType: 'jnt:acl',
+            properties: [
+                {name: 'j:inherit', value: 'false'}
+            ]
+        });
+
+        cy
+            .apolloClient({username: username, password: password})
+            .apollo({
+                queryFile: 'site/getAllSitesWithHomePage.graphql'
+            }).should(result => {
+                const site = getSite(result, siteName);
+                expect(site).to.have.property('name', siteName);
+                expect(site).to.have.property('site');
+                expect(site.site).to.have.property('homePage', null, 'Unauthorized user should not see the homePage field');
+            });
+    });
+});
+
+function getSite(result, siteName) {
+    const sites = result.data.jcr.nodesByQuery.nodes.filter(s => s.name === siteName);
+    expect(sites).to.have.lengthOf(1);
+    return sites[0];
+}

--- a/tests/cypress/e2e/api/site.cy.ts
+++ b/tests/cypress/e2e/api/site.cy.ts
@@ -17,6 +17,10 @@ describe('Test graphql site queries', () => {
         deleteUser(username);
     });
 
+    after('Logout', () => {
+        cy.logout();
+    });
+
     it('Should be able to read the homePage property when requested as root', () => {
         cy.apollo({
             queryFile: 'site/getAllSitesWithHomePage.graphql'

--- a/tests/cypress/fixtures/site/getAllSitesWithHomePage.graphql
+++ b/tests/cypress/fixtures/site/getAllSitesWithHomePage.graphql
@@ -1,0 +1,18 @@
+query {
+    jcr(workspace: EDIT) {
+        nodesByQuery(
+            query: "select * from [jnt:virtualsite] where ischildnode('/sites')"
+        ) {
+            nodes {
+                name
+                site {
+                    homePage {
+                        path
+                        name
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15289

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Gracefully handle scenarios where the home page has restricted access by returning `null` for the `homePage` field of the GraphQL JCRSite query.

Depends on https://github.com/Jahia/graphql-core/pull/465.


## Tests

The following are included in this PR
- [x] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [x] Inline documentation
- [x] User-facing Documentation
