### PR TITLE
QA-15318: Prevent NPE when getting groups of a principal

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
@@ -23,13 +23,14 @@ import org.jahia.modules.graphql.provider.dxm.predicate.*;
 import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedData;
 import org.jahia.modules.graphql.provider.dxm.relay.DXPaginatedDataConnectionFetcher;
 import org.jahia.modules.graphql.provider.dxm.relay.PaginationHelper;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.modules.graphql.provider.dxm.site.GqlJcrSite;
+import org.jahia.services.content.decorator.JCRGroupNode;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
 import pl.touk.throwing.ThrowingPredicate;
 
 import javax.jcr.RepositoryException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 @GraphQLName("Principal")
@@ -46,7 +47,9 @@ public interface GqlPrincipal {
 
         List<String> paths = groupManagerService.getMembershipByPath(localPath);
         Stream<GqlGroup> stream = paths.stream()
-                .map(path -> groupManagerService.lookupGroupByPath(path).getJahiaGroup())
+                .map(groupManagerService::lookupGroupByPath)
+                .filter(Objects::nonNull)
+                .map(JCRGroupNode::getJahiaGroup)
                 .filter(group -> !group.isHidden())
                 .filter(ThrowingPredicate.unchecked(n -> site == null || n.getLocalPath().startsWith("/sites/" + site + "/")))
                 .map(GqlGroup::new)

--- a/tests/cypress/fixtures/groovy/flushCache.groovy
+++ b/tests/cypress/fixtures/groovy/flushCache.groovy
@@ -1,0 +1,3 @@
+import org.jahia.services.cache.CacheHelper
+
+CacheHelper.flushEhcacheByName("CACHE_NAME")


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15318

## Description
Prevent a `NullPointerException` when getting group memberships of a principal in GraphQL.
The list of groups are retrieved from a cache, which therefore could return a group specific to a site (i.e.: `/sites/<your site>/groups/site-users`) that no longer exists and therefore `GroupManagerService#lookupGroupByPath()` would return `null`  leading to a `NullPointerException`:
```
java.lang.NullPointerException: Cannot invoke "org.jahia.services.content.decorator.JCRGroupNode.getJahiaGroup()" because the return value of "org.jahia.services.usermanager.JahiaGroupManagerService.lookupGroupByPath(String)" is null
	at org.jahia.modules.graphql.provider.dxm.user.GqlPrincipal.lambda$getGroupMembership$0(GqlPrincipal.java:50) ~[?:?]
```

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [x] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability
