### PR TITLE
BACKLOG-23325 : depth for node field / max depth param for descendant…

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNode.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNode.java
@@ -86,6 +86,15 @@ public interface GqlJcrNode {
     String getPath();
 
     /**
+     * @return The depth of the JCR node this object represents
+     */
+    @GraphQLField
+    @GraphQLName("depth")
+    @GraphQLNonNull
+    @GraphQLDescription("The depth in the JCR Tree of the JCR node this object represents")
+    Integer getDepth();
+
+    /**
      * @param language The language to obtain the display name in
      * @return The display name of the JCR node this object represents in the requested language
      */
@@ -196,6 +205,7 @@ public interface GqlJcrNode {
                                                @GraphQLName("recursionTypesFilter") @GraphQLDescription("Filter out and stop recursion on nodes by their types; null to avoid such filtering") NodeTypesInput recursionTypesFilter,
                                                @GraphQLName("recursionPropertiesFilter") @GraphQLDescription("Filter out and stop recursion on nodes by their property values; null to avoid such filtering") NodePropertiesInput recursionPropertiesFilter,
                                                @GraphQLName("fieldFilter") @GraphQLDescription("Filter by graphQL fields values") FieldFiltersInput fieldFilter,
+                                               @GraphQLName("maxDepth") @GraphQLDescription("Maximum depth in JCR tree for descendants from the current node, 0 (or less) for all sub nodes, 1 for one sub level, etc") Integer maxDepth,
                                                @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,
                                                @GraphQLName("fieldGrouping") @GraphQLDescription("Group fields according to specified criteria") FieldGroupingInput fieldGrouping,
                                                DataFetchingEnvironment environment)

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
@@ -209,7 +209,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
                                                             @GraphQLName("recursionPropertiesFilter") @GraphQLDescription("Filter out and stop recursion on nodes by their property values; null to avoid such filtering") GqlJcrNode.NodePropertiesInput recursionPropertiesFilter) throws BaseGqlClientException {
         List<GqlJcrNodeMutation> descendants = new LinkedList<>();
         try {
-            NodeHelper.collectDescendants(jcrNode, NodeHelper.getNodesPredicate(null, typesFilter, propertiesFilter, null),  NodeHelper.getNodesPredicate(null, recursionTypesFilter, recursionPropertiesFilter, null),  descendant -> descendants.add(new GqlJcrNodeMutation(descendant)));
+            NodeHelper.collectDescendants(jcrNode, NodeHelper.getNodesPredicate(null, typesFilter, propertiesFilter, null, null),  NodeHelper.getNodesPredicate(null, recursionTypesFilter, recursionPropertiesFilter, null, null),  descendant -> descendants.add(new GqlJcrNodeMutation(descendant)));
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -233,7 +233,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
     throws BaseGqlClientException {
         List<GqlJcrNodeMutation> children = new LinkedList<>();
         try {
-            NodeHelper.collectDescendants(jcrNode, NodeHelper.getNodesPredicate(names, typesFilter, propertiesFilter, null), PredicateHelper.falsePredicate(), child -> children.add(new GqlJcrNodeMutation(child)));
+            NodeHelper.collectDescendants(jcrNode, NodeHelper.getNodesPredicate(names, typesFilter, propertiesFilter, null, null), PredicateHelper.falsePredicate(), child -> children.add(new GqlJcrNodeMutation(child)));
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }

--- a/tests/cypress/e2e/api/jcr/getNode.cy.ts
+++ b/tests/cypress/e2e/api/jcr/getNode.cy.ts
@@ -14,6 +14,12 @@ describe('Get node graphql test', () => {
 
     before('load graphql file and create nodes', () => {
         cy.apollo({
+            mutationFile: 'jcr/deleteNode.graphql',
+            variables: {
+                pathOrId: '/testList'
+            }
+        });
+        cy.apollo({
             mutationFile: 'jcr/addNode.graphql',
             variables: {
                 parentPathOrId: '/',
@@ -32,6 +38,19 @@ describe('Get node graphql test', () => {
             nodeUuid = response.data.jcr.addNode.uuid;
             subNodeUuid1 = response.data.jcr.addNode.addChildrenBatch[0].uuid;
             subNodeUuid2 = response.data.jcr.addNode.addChildrenBatch[1].uuid;
+        });
+        // Create sub nodes
+        cy.apollo({
+            mutationFile: 'jcr/addNode.graphql',
+            variables: {
+                parentPathOrId: '/testList/testSubList1',
+                nodeName: 'testSubList1-1',
+                nodeType: 'jnt:contentList',
+                children: [
+                    {name: 'testSubList1-1-1', primaryNodeType: 'jnt:contentList'},
+                    {name: 'testSubList1-1-2', primaryNodeType: 'jnt:contentList'}
+                ]
+            }
         });
     });
 
@@ -275,6 +294,79 @@ describe('Get node graphql test', () => {
         });
     });
 
+    it('Get descendant nodes with a given maxDepth', () => {
+        cy.apollo({
+            query: gql`
+                {
+                  jcr {
+                    result: nodeByPath(path: "/testList") {
+                      descendants(maxDepth: 2) {
+                        nodes {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }`,
+            errorPolicy: 'all'
+        }).should(result => {
+            const nodes = result?.data?.jcr?.result?.descendants?.nodes;
+            expect(nodes).to.have.length(3);
+            expect(nodes[0].name).to.equal('testSubList1');
+            expect(nodes[1].name).to.equal('testSubList1-1');
+            expect(nodes[2].name).to.equal('testSubList2');
+        });
+    });
+
+    it('Get ALL descendant nodes with a 0 or negative maxDepth', () => {
+        [0, -1].forEach(depth => cy.apollo({
+            query: gql`
+                {
+                  jcr {
+                    result: nodeByPath(path: "/testList") {
+                      descendants(maxDepth: ${depth}) {
+                        nodes {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }`,
+            errorPolicy: 'all'
+        }).should(result => {
+            const nodes = result?.data?.jcr?.result?.descendants?.nodes;
+            expect(nodes).to.have.length(5);
+            expect(nodes[0].name).to.equal('testSubList1');
+            expect(nodes[1].name).to.equal('testSubList1-1');
+            expect(nodes[2].name).to.equal('testSubList1-1-1');
+            expect(nodes[3].name).to.equal('testSubList1-1-2');
+            expect(nodes[4].name).to.equal('testSubList2');
+        }));
+    });
+
+    it.only('Get node depth', () => {
+        const results = [
+            {depth: 0, path: '/'},
+            {depth: 1, path: '/testList'},
+            {depth: 2, path: '/testList/testSubList1'},
+            {depth: 3, path: '/testList/testSubList1/testSubList1-1'},
+            {depth: 4, path: '/testList/testSubList1/testSubList1-1/testSubList1-1-1'}
+        ];
+        results.forEach(result => cy.apollo({
+            query: gql`
+                {
+                  jcr {
+                    result: nodeByPath(path: "${result.path}") {
+                      depth
+                    }
+                  }
+                }`,
+            errorPolicy: 'all'
+        }).should(response => {
+            expect(response?.data?.jcr?.result?.depth).to.equal(result.depth);
+        }));
+    });
+
     after('Delete testList node', function () {
         cy.apollo({
             mutationFile: 'jcr/deleteNode.graphql',
@@ -284,3 +376,4 @@ describe('Get node graphql test', () => {
         });
     });
 });
+


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23325

## depth
Add `depth` field to node field. 
This returns the depth of the node in the JCR tree

## maxDepth
Add `maxDepth` to `descendants` attributes.
This defines the max depth, relative to the current node, to returns descendants.
`0` (or any negative value) means all descendants

Covered by integration tests