### PR TITLE
SEC-116: Remove no longer needed king-http-client

### DIFF
--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -70,11 +70,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.king.king-http-client</groupId>
-            <artifactId>king-http-client</artifactId>
-            <version>3.0.22</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.31</version>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/SEC-116

## Description

king-http-client was introduced for the GraphQLSchedulerTest ([this commit](https://github.com/Jahia/graphql-core/commit/0087ebeb7e30a53d753a01111f4755261426b514#diff-8a2f7a5330c3c9bee3015017c1930a01e86e7ee7cc7cc56e088b291b2a9b093bR102)) and should have recently been removed with #449 ([QABACKLOG-1525](https://jira.jahia.org/browse/QABACKLOG-1525)). The removal of the no longer needed library also removes the packaging of the vulnerable netty version.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
