### PR TITLE
QA-14843: Enable video for Cypress tests

### DIFF
--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -3,6 +3,7 @@ import {defineConfig} from 'cypress';
 export default defineConfig({
     chromeWebSecurity: false,
     defaultCommandTimeout: 10000,
+    video: true,
     videoUploadOnPasses: false,
     reporter: 'cypress-multi-reporters',
     reporterOptions: {


### PR DESCRIPTION

https://jira.jahia.org/browse/QA-14843
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Since the upgrade to Cypress 13 (in [this change](https://github.com/Jahia/graphql-core/pull/350/files#diff-c7273ca77f452520adba2dfb738cd146b83110e7faa7b861318e89b2b56b5d56R16)), the video configuration option now defaults to false and must be explicitly enabled.
See https://docs.cypress.io/app/references/changelog#13-0-0 for details.
