### PR TITLE
QA-15315 Backport of deletePropertiesBatch node

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrDeletedPropertyInput.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrDeletedPropertyInput.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.node;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
+
+@GraphQLName("JCRDeletedProperty")
+@GraphQLDescription("GraphQL representation of a deleted JCR property")
+public class GqlJcrDeletedPropertyInput {
+    protected String name;
+    protected String language;
+
+    public GqlJcrDeletedPropertyInput(@GraphQLName("name") @GraphQLNonNull @GraphQLDescription("The name of the property to delete") String name,
+                                      @GraphQLName("language") @GraphQLNonNull @GraphQLDescription("The language in which the property will be deleted") String language) {
+        this.name = name;
+        this.language = language;
+    }
+
+    @GraphQLField
+    @GraphQLName("name")
+    @GraphQLNonNull
+    @GraphQLDescription("The name of the property to delete")
+    public String getName() {
+        return name;
+    }
+
+    @GraphQLField
+    @GraphQLName("language")
+    @GraphQLNonNull
+    @GraphQLDescription("The language in which the property will be deleted")
+    public String getLanguage() {
+        return language;
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrMutationSupport.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrMutationSupport.java
@@ -117,6 +117,32 @@ public class GqlJcrMutationSupport {
     }
 
     /**
+     * Delete the provided properties to the specified node.
+     *
+     * @param node       The JCR node to delete properties from
+     * @param properties the collection of properties to be deleted
+     * @return Boolean
+     */
+    public static boolean deleteProperties(JCRNodeWrapper node, Collection<GqlJcrDeletedPropertyInput> properties) {
+        if (properties == null) {
+            return false;
+        }
+
+        for (GqlJcrDeletedPropertyInput prop : properties) {
+            try {
+                JCRNodeWrapper localizedNode = NodeHelper.getNodeInLanguage(node, prop.getLanguage());
+                if (localizedNode.hasProperty(prop.getName())) {
+                    localizedNode.getProperty(prop.getName()).remove();
+                }
+            } catch (RepositoryException e) {
+                throw new DataFetchingException(e);
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Retrieve the specified JCR node by its path or UUID.
      *
      * @param session  JCR session to be used for node retrieval

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
@@ -268,6 +268,20 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
     }
 
     /**
+     * Performs batch-delete of the specified properties on the JCR node.
+     *
+     * @param properties the collection of properties to be deleted
+     * @return Boolean
+     * @throws BaseGqlClientException in case of modification errors
+     */
+    @GraphQLField
+    @GraphQLName("deletePropertiesBatch")
+    @GraphQLDescription("Deletes a set of properties on the current node")
+    public Boolean deletePropertiesBatch(@GraphQLName("properties") @GraphQLDescription("The collection of JCR properties: name and language") Collection<GqlJcrDeletedPropertyInput> properties) {
+        return deleteProperties(jcrNode, properties);
+    }
+
+    /**
      * Performs batch-set of the specified properties on the JCR node.
      *
      * @param properties the collection of properties to be set

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
@@ -172,7 +172,7 @@ public class NodeHelper {
         String workspace = node.getSession().getWorkspace().getName();
         if (language == null) {
             if (node.getLanguage() != null) {
-                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace);
+                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, Locale.forLanguageTag(node.getLanguage()));
                 return session.getNodeByIdentifier(node.getIdentifier());
             }
             return node;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Backport from v3 to support clearing multiple localized properties.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
