### PR TITLE
BACKLOG-22479: Improve logging for SDL definition status

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLSchemaService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLSchemaService.java
@@ -129,7 +129,7 @@ public class SDLSchemaService {
                 sources.keySet().removeAll(invalidTypes);
                 invalidTypes.forEach(typeDefinitionRegistry::remove);
             } while (!invalidTypes.isEmpty());
-            SDLTypeChecker.printStatuses(sdlDefinitionStatusMap);
+            SDLTypeChecker.printStatuses(sdlDefinitionStatusMap.values());
             SchemaGenerator schemaGenerator = new SchemaGenerator();
 
             TypeDefinitionRegistry cleanedTypeRegistry = new TypeDefinitionRegistry();

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLTypeChecker.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/SDLTypeChecker.java
@@ -156,8 +156,19 @@ public class SDLTypeChecker {
         return status;
     }
 
-    public static void printStatuses(Map<String, SDLDefinitionStatus> statusMap) {
-        statusMap.values().forEach(e -> logger.info(e.toString()));
+    /**
+     * Print and log SDL definition status.
+     * If status is not OK, it will be logged as error. Otherwise, it logs status only if debug is enabled.
+     * @param statuses list of statuses to log
+     */
+    public static void printStatuses(Collection<SDLDefinitionStatus> statuses) {
+        statuses.forEach(e -> {
+            if (e.getStatus() != SDLDefinitionStatusType.OK) {
+                logger.error(e.toString());
+            } else if (logger.isDebugEnabled()) {
+                logger.debug(e.toString());
+            }
+        });
     }
 
     private static SDLDefinitionStatus checkForFieldsConsistency(SDLSchemaService sdlSchemaService, ObjectTypeDefinition objectTypeDefinition, TypeDefinitionRegistry typeDefinitionRegistry) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatus.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/parsing/status/SDLDefinitionStatus.java
@@ -53,12 +53,11 @@ public class SDLDefinitionStatus {
 
     @Override
     public String toString() {
-        return String.format("DEFINITION: %s maps to type %s from module %s with id %s. STATUS: %s",
-                this.name,
-                this.mapsToType,
-                this.mappedTypeModuleName,
-                this.mappedTypeModuleId,
-                getStatusString());
+        String info = String.format("%s maps to type %s", this.name, this.mapsToType);
+        if (mappedTypeModuleName != null) {
+            info += String.format(" from module %s with id %s", this.mappedTypeModuleName, this.mappedTypeModuleId);
+        }
+        return String.format("DEFINITION: %s. STATUS: %s", info, getStatusString());
     }
 
     public String getStatusString() {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Minimize/improve logging coming from SDLTypeChecker:

- Include module info in log, only if available
- filter status logging so that we always log non-OK status as error, else we log OK status info only if debug is enabled on SDLTypeChecker
