### PR TITLE
BACKLOG-23491: Restore api description at Query level 

### DIFF
--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -21,9 +21,6 @@ describe('Test for GraphQL schema description', () => {
         'AdminQuery/jahia/JahiaAdminQuery/GqlHealthCheck',
         'AdminQuery/jahia/JahiaAdminQuery/load',
 
-        // Tools - BACKLOG-23491
-        'AdminQuery/tools/AdminTools/bundles/BundleWithDependencies/dependencies/BundleDependency/status/Status',
-
         // Missing but provided by: https://github.com/Jahia/personal-api-tokens
         'AdminQuery/personalApiTokens/PersonalApiTokensQuery',
 

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -53,7 +53,9 @@ describe('Test for GraphQL schema description', () => {
         'Subscription/workflowEvent/GqlWorkflowEvent'
     ];
 
-    // eslint-disable-next-line no-warning-comments
+    // Note: If you need to remove a node missing a description, please use the noDescBlacklist
+    // array, do not filter out one of the entryNodes entirely as it will make the test blind
+    // to any further updates to the schema.
     const entryNodes = ['Query', 'Mutation', 'Subscription'];
     entryNodes.forEach(entryNode => {
         it(`Description for all nodes under ${entryNode}`, () => {

--- a/tests/cypress/e2e/api/apiDescription.cy.ts
+++ b/tests/cypress/e2e/api/apiDescription.cy.ts
@@ -17,10 +17,12 @@ describe('Test for GraphQL schema description', () => {
         'GqlDashboard',
 
         // Missing but provided by: https://github.com/Jahia/server-availability-manager
-
         'AdminQuery/jahia/JahiaAdminQuery/healthCheck',
         'AdminQuery/jahia/JahiaAdminQuery/GqlHealthCheck',
         'AdminQuery/jahia/JahiaAdminQuery/load',
+
+        // Tools - BACKLOG-23491
+        'AdminQuery/tools/AdminTools/bundles/BundleWithDependencies/dependencies/BundleDependency/status/Status',
 
         // Missing but provided by: https://github.com/Jahia/personal-api-tokens
         'AdminQuery/personalApiTokens/PersonalApiTokensQuery',
@@ -52,8 +54,7 @@ describe('Test for GraphQL schema description', () => {
     ];
 
     // eslint-disable-next-line no-warning-comments
-    // TODO: BACKLOG-23491 | Enable query test back after fixing the tools module
-    const entryNodes = ['Mutation', 'Subscription'];
+    const entryNodes = ['Query', 'Mutation', 'Subscription'];
     entryNodes.forEach(entryNode => {
         it(`Description for all nodes under ${entryNode}`, () => {
             getDescriptions(entryNode).then(result => {


### PR DESCRIPTION
This reverts the change to ignore `Query` done in #476 

If we ignore the entire Query node, indeed we will not get failed tests for the missing description in tools, but any other missing descriptions added while this test is disabled will be missed.

A better solution is to filter the single node missing a description.
