### PR TITLE
TECH-2029: Updated name of the java runtime in tests

### DIFF
--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -9,7 +9,7 @@ describe('Test admin jahia cluster endpoint', () => {
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
-            expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
+            expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3);


### PR DESCRIPTION
https://jira.jahia.org/browse/TECH-2029