### PR TITLE
TECH-2029: Fixed a compatibility issue with the runtime name

### DIFF
--- a/.github/workflows/nightly-RL.yml
+++ b/.github/workflows/nightly-RL.yml
@@ -16,3 +16,4 @@ jobs:
       pagerduty_incident_service: graphql-dxm-provider-JahiaRL
       provisioning_manifest: provisioning-manifest-snapshot.yml
       artifact_prefix: gql
+      module_branch: ${{ github.ref }}

--- a/.github/workflows/nightly-SN.yml
+++ b/.github/workflows/nightly-SN.yml
@@ -16,3 +16,5 @@ jobs:
       pagerduty_incident_service: graphql-dxm-provider-JahiaSN
       provisioning_manifest: provisioning-manifest-snapshot.yml
       artifact_prefix: gql
+      module_branch: ${{ github.ref }}
+

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { getJahiaVersion } from '@jahia/cypress'
 
 describe('Test admin jahia cluster endpoint', () => {
     it('Gets cluster details', () => {
@@ -9,7 +10,15 @@ describe('Test admin jahia cluster endpoint', () => {
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
-            expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
+            getJahiaVersion().then((jahiaVersion) => {
+                console.log(jahiaVersion)
+                if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
+                    expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
+                } else {
+                    // With TECH-2029 the GraalVM vendor was changed, resulting in a new runtime name
+                    expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
+                }
+            })
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3);

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { getJahiaVersion } from '@jahia/cypress'
-import { compare } from 'compare-versions'
+/* eslint max-nested-callbacks: ["error", 5] */
+import {getJahiaVersion} from '@jahia/cypress';
+import {compare} from 'compare-versions';
 
 describe('Test admin jahia system endpoint', () => {
     it('Gets system details', () => {
@@ -11,16 +12,16 @@ describe('Test admin jahia system endpoint', () => {
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
-            getJahiaVersion().then((jahiaVersion) => {
+            getJahiaVersion().then(jahiaVersion => {
                 cy.log(JSON.stringify(jahiaVersion)).then(() => {
                     if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
                         expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
                     } else {
                         // With TECH-2029 the GraalVM vendor was changed, resulting in a new runtime name
                         expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
-                    }                    
-                })
-            })
+                    }
+                });
+            });
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3);

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getJahiaVersion } from '@jahia/cypress'
 
-describe('Test admin jahia cluster endpoint', () => {
-    it('Gets cluster details', () => {
+describe('Test admin jahia system endpoint', () => {
+    it('Gets system details', () => {
         cy.apollo({
             queryFile: 'admin/system.graphql'
         }).should((response: any) => {

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -11,13 +11,14 @@ describe('Test admin jahia cluster endpoint', () => {
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
             getJahiaVersion().then((jahiaVersion) => {
-                cy.log(jahiaVersion)
-                if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
-                    expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
-                } else {
-                    // With TECH-2029 the GraalVM vendor was changed, resulting in a new runtime name
-                    expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
-                }
+                cy.log(jahiaVersion).then(() => 
+                    if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
+                        expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
+                    } else {
+                        // With TECH-2029 the GraalVM vendor was changed, resulting in a new runtime name
+                        expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
+                    }                    
+                })
             })
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3);

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -11,7 +11,7 @@ describe('Test admin jahia system endpoint', () => {
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
             getJahiaVersion().then((jahiaVersion) => {
-                cy.log(jahiaVersion).then(() => 
+                cy.log(jahiaVersion).then(() => {
                     if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
                         expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
                     } else {

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,17 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getJahiaVersion } from '@jahia/cypress'
+import { compare } from 'compare-versions'
 
 describe('Test admin jahia system endpoint', () => {
     it('Gets system details', () => {
         cy.apollo({
             queryFile: 'admin/system.graphql'
-        }).should((response: any) => {
+        }).then((response: any) => {
             expect(response.data.admin.jahia.system.os.name).to.equal('Linux');
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
             getJahiaVersion().then((jahiaVersion) => {
-                cy.log(jahiaVersion).then(() => {
+                cy.log(JSON.stringify(jahiaVersion)).then(() => {
                     if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
                         expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
                     } else {

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -11,7 +11,7 @@ describe('Test admin jahia cluster endpoint', () => {
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
             getJahiaVersion().then((jahiaVersion) => {
-                console.log(jahiaVersion)
+                cy.log(jahiaVersion)
                 if (compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.1', '<')) {
                     expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
                 } else {

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,6 +12,7 @@
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "babel-plugin-istanbul": "^6.1.1",
+    "compare-versions": "^6.1.1",
     "cross-fetch": "^3.1.4",
     "cypress": "13.6.4",
     "cypress-file-upload": "^5.0.8",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -3782,6 +3782,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
https://jira.jahia.org/browse/TECH-2029

Note: For better compatibility of the tests with various environments, I could have checked for content in the string and not for the actual string. But decided to leave it as-is for the time being, we can always update the tests later on.