### PR TITLE
fix(tests): Align version in tests modules

### DIFF
--- a/tests/jahia-module/render-property-test-module/pom.xml
+++ b/tests/jahia-module/render-property-test-module/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+            <version>3.5.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/tests/jahia-module/scheduler-test-module/pom.xml
+++ b/tests/jahia-module/scheduler-test-module/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+            <version>3.5.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Description
Align the version of `graphql-dxm-provider` in the test modules with the current version (3.5.0-SNAPSHOT).
Currently, the [CI fails](https://github.com/Jahia/graphql-core/actions/runs/13992863569/job/39181071349):
```
Error:  Failed to execute goal on project render-property-test-module: Could not resolve dependencies for project org.jahia.test:render-property-test-module:bundle:1.0.0-SNAPSHOT: The following artifacts could not be resolved: org.jahia.modules:graphql-dxm-provider:jar:3.2.0-SNAPSHOT (absent): Could not find artifact org.jahia.modules:graphql-dxm-provider:jar:3.2.0-SNAPSHOT in jahia-internal (https://devtools.jahia.com/nexus/content/groups/internal/) -> [Help 1]
```
Ideally, we should use a Maven multi-module to specify this version only once...


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
