### PR TITLE
chore: add logs in debug in event listener

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/PublicationJobEventListener.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/PublicationJobEventListener.java
@@ -62,8 +62,20 @@ public class PublicationJobEventListener implements EventHandler, RecordConsumer
         List<String> revisions = (List<String>) event.getProperty("revision");
 
         if (revisions != null && clusterNode != null && Long.parseLong(revisions.get(0)) > clusterNode.getRevision()) {
+            logger.debug("Storing event for revision {}, cluster node revision is {}", revisions.get(0), clusterNode.getRevision());
             eventForRevision.put(Long.parseLong(revisions.get(0)), event);
         } else {
+            if (logger.isDebugEnabled()){
+                logger.debug("Notifying listeners for event {}", event.getTopic());
+                if (revisions != null && !revisions.isEmpty()) {
+                    logger.debug("Event revision: {}", revisions.get(0));
+                }
+                if (clusterNode != null) {
+                    logger.debug("Cluster node revision: {}", clusterNode.getRevision());
+                } else {
+                    logger.debug("Cluster node is null");
+                }
+            }
             PublicationJobSubscriptionExtension.notifyListeners(event);
         }
     }
@@ -85,7 +97,9 @@ public class PublicationJobEventListener implements EventHandler, RecordConsumer
 
     @Override
     public void setRevision(long l) {
+        logger.debug("Received revision {}", l);
         if (eventForRevision.containsKey(l)) {
+            logger.debug("Remove revision {} and send notification to listeners", l);
             PublicationJobSubscriptionExtension.notifyListeners(eventForRevision.get(l));
             eventForRevision.remove(l);
         }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/PublicationJobSubscriptionExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/PublicationJobSubscriptionExtension.java
@@ -55,6 +55,7 @@ public class PublicationJobSubscriptionExtension {
     }
 
     public static void notifyListeners(Event event) {
+        logger.debug("Notifying listeners for event {}, number of listeners: {}", event.getTopic(), listeners.size());
         if (!listeners.isEmpty()) {
             String eventTopic = event.getTopic();
             logger.debug("Received event on topic {}", eventTopic);


### PR DESCRIPTION
### Description
Add logs in debug in Event listener to try to figure out why the client does not receive events when a publication is ended.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
