### PR TITLE
fix: Introduce parts number check for upload

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>org.jahia.test</groupId>
             <artifactId>module-test-framework</artifactId>
-            <version>8.2.0.0</version>
+            <version>8.2.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.jahia.test</groupId>
             <artifactId>jahia-test-module</artifactId>
-            <version>8.2.0.0</version>
+            <version>8.2.2.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-core-root</artifactId>
     <name>Jahia GraphQL Core Root</name>


### PR DESCRIPTION
### Description
Introduce parts number check for upload. Multipart request can be used to trigger ddos attack. Similar issue was address in the core by upgrading apache's `commons-upload` library and introducing new param. See http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-24998 for details about the issue. 
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
