### PR TITLE
fix: Prevent ddos attacks by limiting parts for upload requests

### DIFF
--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/graphql.kickstart.servlet.OsgiGraphQLHttpServlet.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/graphql.kickstart.servlet.OsgiGraphQLHttpServlet.cfg
@@ -1,4 +1,5 @@
 alias=/graphql
 osgi.http.whiteboard.servlet.asyncSupported=false
 osgi.http.whiteboard.servlet.multipart.enabled=true
+osgi.http.whiteboard.servlet.multipart.maxRequestSize=100
 jmx.objectname=graphql.servlet:type=graphql


### PR DESCRIPTION
### Description
Prevent ddos attacks by limiting parts for upload requests. 

We did an update to commons-fileupload following a security issues https://github.com/Jahia/jahia-private/issues/2843, https://nvd.nist.gov/vuln/detail/CVE-2023-24998

Graphql servlet already provides the mechanism to limit parts number. I believe we should use this mechanism to prevent potential attacks.

Copilot seems to think that a good values to use is between 10 and 50, I put in 100 which it says is also often used. The key here seems to not have it open to infinity.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
