### PR TITLE
fix: Allow modification of translation nodes directly using full path

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
@@ -172,7 +172,7 @@ public class NodeHelper {
         String workspace = node.getSession().getWorkspace().getName();
         if (language == null) {
             if (node.getLanguage() != null) {
-                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace, Locale.forLanguageTag(node.getLanguage()));
+                JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession(workspace);
                 return session.getNodeByIdentifier(node.getIdentifier());
             }
             return node;

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     </scm>
 
     <properties>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia.nexus.staging.repository.id>64277f72646358</jahia.nexus.staging.repository.id>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </scm>
 
     <properties>
-        <jahia.plugin.version>6.9</jahia.plugin.version>
+        <jahia.plugin.version>6.8.1</jahia.plugin.version>
         <jahia.nexus.staging.repository.id>64277f72646358</jahia.nexus.staging.repository.id>
     </properties>
 


### PR DESCRIPTION
### Description
This line was back ported from GQL 3.x when back porting a fix for CTOL. I have removed it and verified that it is not needed for CTOL. Without it, queries like:
```
mutation ModifyDescription {
  jcr {
    mutateNode(
      pathOrId: "/sites/digitall/home/area-main/area/area/area/area-main/global-network-rich-text/j:translation_fr"
    ) {
      mutateProperty(name: "text") {
        setValue(type: STRING, value: "new value fr!!")
      }
    }
    modifiedNodes {
      path
    }
  }
}
```
Work correctly. In 3.x, this query also works, but there are many more changes to the NodeHelper as well.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
