### PR TITLE
fix: enable query depth & complexity (CVE-2024-40094)

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentationProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentationProvider.java
@@ -15,6 +15,8 @@
  */
 package org.jahia.modules.graphql.provider.dxm.instrumentation;
 
+import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.analysis.MaxQueryDepthInstrumentation;
 import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.kickstart.execution.config.InstrumentationProvider;
@@ -54,6 +56,12 @@ public class JCRInstrumentationProvider implements InstrumentationProvider {
     public Instrumentation getInstrumentation() {
         List<Instrumentation> instns = new ArrayList<>();
         instns.add(new JCRInstrumentation(dxGraphQLConfig));
+        if (dxGraphQLConfig.getDepthLimit() > 0) {
+            instns.add(new MaxQueryDepthInstrumentation(dxGraphQLConfig.getDepthLimit()));
+        }
+        if (dxGraphQLConfig.getComplexityLimit() > 0) {
+            instns.add(new MaxQueryComplexityInstrumentation(dxGraphQLConfig.getComplexityLimit()));
+        }
         instns.addAll(instrumentations.stream()
                 .sorted(Comparator.comparingInt(JahiaInstrumentation::getPriority))
                 .map(inst -> inst.getInstrumentation(dxGraphQLConfig))

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -39,3 +39,14 @@ graphql.fields.node.limit = 5000
 # Introspection queries are enabled by default for development mode, and disabled by default in production mode.
 # Needs to restart graphql-dxm-provider module to take effect
 # graphql.introspection.enabled = false
+
+# The maximum query depth above which the execution is stopped, see graphql.analysis.MaxQueryDepthInstrumentation for details.
+# Use zero or a negative number to disable this check.
+# Needs to restart graphql-dxm-provider module to take effect.
+graphql.depth.limit = 20
+
+# The maximum complexity above which the execution is stopped, see graphql.analysis.MaxQueryComplexityInstrumentation for details.
+# The complexity of a query is calculated by summing up the number of requested fields and nested levels.
+# Use zero or a negative number to disable this check.
+# Needs to restart graphql-dxm-provider module to take effect.
+graphql.complexity.limit = 500


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/3978.
### Description
Add [MaxQueryDepthInstrumentation](https://github.com/graphql-java/graphql-java/blob/v13.0/src/main/java/graphql/analysis/MaxQueryDepthInstrumentation.java) and [MaxQueryComplexityInstrumentation](https://github.com/graphql-java/graphql-java/blob/v13.0/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java) as instrumentations to the GraphQL queries, to respectively set a threshold on the maximum query depth supported, and to set a threshold on the maximum query complexity.

Its purpose is to mitigate [CVE-2024-40094](https://nvd.nist.gov/vuln/detail/CVE-2024-40094), together with https://github.com/Jahia/graphql-java/pull/1.

By default, the max query depth will be 20 and the max complexity 500.
It is possible to completely turn off those 2 checks by using negative (or 0) values.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
