### PR TITLE
chore: allow higher major version of apache tika

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -120,7 +120,7 @@
             org.apache.taglibs.standard.tag.rt.fmt,
             org.apache.taglibs.standard.tei,
             org.apache.taglibs.unstandard,
-            org.apache.tika;version="[1.27,3)",
+            org.apache.tika;version="[1.27,4)",
             org.jahia.api,
             org.jahia.bin,
             org.jahia.bin.filters.jcr,


### PR DESCRIPTION
Follows https://github.com/Jahia/jahia-private/pull/4264

### Description
Allow for also using Apache Tika v3

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
