### PR TITLE
feat: Add conditional checks when checking introspection permission

### DIFF
--- a/graphql-dxm-provider/src/main/import/permissions.xml
+++ b/graphql-dxm-provider/src/main/import/permissions.xml
@@ -7,7 +7,4 @@
         <graphqlAdminQuery jcr:primaryType="jnt:permission"/>
         <graphqlAdminMutation jcr:primaryType="jnt:permission"/>
     </admin>
-    <developerToolsAccess jcr:primaryType="jnt:permission">
-        <graphqlIntrospection jcr:primaryType="jnt:permission"/>
-    </developerToolsAccess>
 </permissions>

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GqlJcrPermissionChecker.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GqlJcrPermissionChecker.java
@@ -121,9 +121,9 @@ public final class GqlJcrPermissionChecker {
         try {
             JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession();
             sessionUserId = session.getUserID();
-            logger.debug("Checking for introspection permission for user {} ", sessionUserId);
             boolean hasPermission = session.getNode("/").hasPermission(INTROSPECTION_PERMISSION);
             disableIntrospection = !hasPermission;
+            logger.debug("Introspection permission enabled for user {}: {}", sessionUserId, hasPermission);
         } catch (RepositoryException e) {
             logger.error("Introspection permission check failed for user {}. Disabling introspection for this request.", sessionUserId);
             logger.debug(e.getMessage(), e);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GqlJcrPermissionChecker.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/GqlJcrPermissionChecker.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public final class GqlJcrPermissionChecker {
 
-    private static final String INTROSPECTION_PERMISSION = "graphqlIntrospection";
+    private static final String INTROSPECTION_PERMISSION = "developerToolsAccess";
 
     private static final Logger logger = LoggerFactory.getLogger(GqlJcrPermissionChecker.class);
 

--- a/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_de.properties
+++ b/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_de.properties
@@ -1,4 +1,2 @@
 label.permission.graphqlAdminQuery.description=GraphQL Abfrage unter dem Admin Knoten ausführen
 label.permission.graphqlAdminMutation.description=GraphQL Aktualisierungsabfrage unter dem Admin Knoten ausführen
-label.permission.graphqlIntrospection=GraphQL Introspection
-label.permission.graphqlIntrospection.description=Aktiviert GraphQL-Introspektionsfelder und Typdefinitionen

--- a/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_en.properties
+++ b/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_en.properties
@@ -1,4 +1,2 @@
 label.permission.graphqlAdminQuery.description=Perform GraphQL queries under the admin node
 label.permission.graphqlAdminMutation.description=Perform GraphQL mutations under the admin node
-label.permission.graphqlIntrospection=GraphQL Introspection
-label.permission.graphqlIntrospection.description=Enables graphql introspection fields and type definitions

--- a/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_fr.properties
+++ b/graphql-dxm-provider/src/main/resources/resources/graphql-dxm-provider_fr.properties
@@ -1,4 +1,2 @@
 label.permission.graphqlAdminQuery.description=Réaliser des requêtes GraphQL sous le noeud admin
 label.permission.graphqlAdminMutation.description=Réaliser des mutations GraphQL sous le noeud admin
-label.permission.graphqlIntrospection=GraphQL Introspection
-label.permission.graphqlIntrospection.description=Active les champs d'introspection GraphQL et les définitions de types

--- a/tests/cypress/e2e/api/introspection.cy.ts
+++ b/tests/cypress/e2e/api/introspection.cy.ts
@@ -44,6 +44,7 @@ describe('GraphQL Introspection Authorization', () => {
             });
     });
 
+    // `introspectionCheckEnabled=true` is set in jahia.properties on docker-compose
     it('Should block __schema introspection for regular user without permission', () => {
         cy.apolloClient(user)
             .apollo({queryFile: 'introspectionSchema.graphql', errorPolicy: 'all'})

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,9 +4,10 @@ services:
         image: '${JAHIA_IMAGE}'
         container_name: jahia
         environment:
-            - SUPER_USER_PASSWORD=${SUPER_USER_PASSWORD}
-            - MAX_RAM_PERCENTAGE=95
-            - JPDA=true
+            SUPER_USER_PASSWORD: ${SUPER_USER_PASSWORD}
+            JAHIA_PROPERTIES: '"introspectionCheckEnabled":"true"'
+            MAX_RAM_PERCENTAGE: 95
+            JPDA: "true"
         ports:
             - '8000:8000'
             - '8080:8080'


### PR DESCRIPTION
### Description

Add conditional checks before checking for introspection permission:

- We do not check for permission by default unless `introspectionCheckEnabled` is set to true in `jahia.properties` (This will be enabled by default for Jahia 8.3)
- To avoid issues with WS subscription connections (regarding user session), we do introspection check only for graphql Queries (we cannot do introspection on mutation and subscriptions anyways)
- Replace `graphqlIntrospection` permission and reuse `developerToolsAccess` instead for checking introspection access.

#### Tests

- `introspectionCheckEnabled` has been set to true by default at the docker-compose level; possible to remove in the future once it's enabled by default from Jahia core.
