### PR TITLE
feat: Add introspectionCheckEnabled configuration property

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
@@ -26,12 +26,10 @@ import org.jahia.modules.graphql.provider.dxm.osgi.OSGIServiceInjectorDataFetche
 import org.jahia.modules.graphql.provider.dxm.security.GqlJcrPermissionChecker;
 import org.jahia.modules.graphql.provider.dxm.security.GqlJcrPermissionDataFetcher;
 import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
-import org.jahia.settings.SettingsBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * JCR instrumentation implementation
@@ -40,7 +38,6 @@ public class JCRInstrumentation extends SimpleInstrumentation {
 
     public static final String GRAPHQL_VARIABLES = "graphQLVariables";
     public static final String FRAGMENTS_BY_NAME = "fragmentsByName";
-    public static final String INTROSPECTION_CHECK_ENABLED_PROP = "introspectionCheckEnabled";
 
     private static final Logger logger = LoggerFactory.getLogger(JCRInstrumentation.class);
 
@@ -79,7 +76,7 @@ public class JCRInstrumentation extends SimpleInstrumentation {
          * Add filter check to avoid exceptions since introspection can only be done on QUERY operations anyways
          */
         boolean isQueryOperation = OperationDefinition.Operation.QUERY.equals(executionContext.getOperationDefinition().getOperation());
-        boolean isIntrospectionCheckEnabled = SettingsBean.getInstance().getBoolean(INTROSPECTION_CHECK_ENABLED_PROP, false);
+        boolean isIntrospectionCheckEnabled = dxGraphQLConfig.isIntrospectionCheckEnabled();
         logger.debug("isIntrospectionCheckEnabled: {}", isIntrospectionCheckEnabled);
         if (isIntrospectionCheckEnabled && isQueryOperation) {
             GqlJcrPermissionChecker.configureIntrospectionFromPermissions(executionContext.getGraphQLContext());

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -35,5 +35,14 @@
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
 graphql.fields.node.limit = 5000
 
-# Enable GraphQL feature to limit introspection queries only to authorized users (graphql-dxm-provider >= 3.5.0)
+# Controls access to GraphQL introspection queries (requires graphql-dxm-provider >= 3.5.0)
+# Behavior:
+#   - Multiple configuration files may define this property.
+#   - If ANY configuration file sets introspectionCheckEnabled=true, the feature is considered enabled globally.
+# When enabled (true):
+#   - Introspection queries are restricted to users having the permission: developerToolsAccess.
+# When disabled (false):
+#   - Introspection queries are allowed for all users with no permission checks.
+# Default (not set): false, to preserve backward-compatible behavior.
+# Recommended: set to true for improved security on introspection access.
 # introspectionCheckEnabled=true

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -34,3 +34,6 @@
 #
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
 graphql.fields.node.limit = 5000
+
+# Enable GraphQL feature to limit introspection queries only to authorized users (graphql-dxm-provider >= 3.5.0)
+# introspectionCheckEnabled=true

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -12,7 +12,8 @@
     "parser": "@typescript-eslint/parser",
     "rules": {
         "react/boolean-prop-naming": ["error", { "rule": "^((is|has)[A-Z]([A-Za-z0-9]?)+|disabled|readOnly|autoFocus)"}],
-        "@typescript-eslint/no-shadow": ["error"]
+        "@typescript-eslint/no-shadow": ["error"],
+        "@typescript-eslint/no-explicit-any": "off"
     },
     "root": true
 }

--- a/tests/cypress/e2e/api/admin/cluster.cy.ts
+++ b/tests/cypress/e2e/api/admin/cluster.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Test admin jahia cluster endpoint', () => {
     it('Gets cluster details', () => {

--- a/tests/cypress/e2e/api/admin/config.cy.ts
+++ b/tests/cypress/e2e/api/admin/config.cy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import gql from 'graphql-tag';
 
 describe('admin.configuration', () => {

--- a/tests/cypress/e2e/api/admin/database.cy.ts
+++ b/tests/cypress/e2e/api/admin/database.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Test admin jahia database endpoint', () => {
     it('Gets database details', () => {

--- a/tests/cypress/e2e/api/admin/dateTime.cy.ts
+++ b/tests/cypress/e2e/api/admin/dateTime.cy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import {isValid} from 'date-fns';
 
 describe('admin.datetime - Jahia Server time', () => {

--- a/tests/cypress/e2e/api/admin/jahia.cy.ignore.ts
+++ b/tests/cypress/e2e/api/admin/jahia.cy.ignore.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import {DocumentNode} from 'graphql';
 import {isValid} from 'date-fns';
 import {apollo} from '../../../support/apollo';

--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /* eslint max-nested-callbacks: ["error", 5] */
 import {getJahiaVersion} from '@jahia/cypress';
 import {compare} from 'compare-versions';

--- a/tests/cypress/e2e/api/admin/user.cy.ts
+++ b/tests/cypress/e2e/api/admin/user.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {createSite, deleteSite} from '@jahia/cypress';
 

--- a/tests/cypress/e2e/api/admin/users.cy.ts
+++ b/tests/cypress/e2e/api/admin/users.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Test admin users endpont', () => {
     before('load graphql file', () => {

--- a/tests/cypress/e2e/api/currentUser.cy.ts
+++ b/tests/cypress/e2e/api/currentUser.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Validate ability get current User', () => {
     it('Get Current user for Authenticated user (irina)', () => {

--- a/tests/cypress/e2e/api/jcr/checkNodePropertyType.cy.ts
+++ b/tests/cypress/e2e/api/jcr/checkNodePropertyType.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Test page properties', () => {
     before('load graphql file and create node', () => {

--- a/tests/cypress/e2e/api/jcr/fileGrouping.cy.ts
+++ b/tests/cypress/e2e/api/jcr/fileGrouping.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import gql from 'graphql-tag';
 

--- a/tests/cypress/e2e/api/jcr/getNode.cy.ts
+++ b/tests/cypress/e2e/api/jcr/getNode.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import gql from 'graphql-tag';
 import {validateErrors} from './validateErrors';

--- a/tests/cypress/e2e/api/jcr/getTranslatedProperties.cy.ts
+++ b/tests/cypress/e2e/api/jcr/getTranslatedProperties.cy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('Get properties graphql test', () => {
     const textValueEnglish = 'text EN';

--- a/tests/cypress/e2e/api/jcr/graphqlQueryTest.cy.ts
+++ b/tests/cypress/e2e/api/jcr/graphqlQueryTest.cy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import gql from 'graphql-tag';
 import {validateError} from './validateErrors';
 

--- a/tests/cypress/e2e/api/jcr/validateErrors.ts
+++ b/tests/cypress/e2e/api/jcr/validateErrors.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import {ApolloQueryResult, FetchResult} from '@apollo/client';
 
 export function validateError(

--- a/tests/cypress/fixtures/admin/configuration.ts
+++ b/tests/cypress/fixtures/admin/configuration.ts
@@ -1,0 +1,54 @@
+import gql from 'graphql-tag';
+import Chainable = Cypress.Chainable;
+import {ApolloQueryResult, FetchResult} from '@apollo/client';
+
+const pid = 'org.jahia.modules.graphql.provider';
+
+export const setGqlConfig = (name: string, value: string) : Chainable<ApolloQueryResult<any> | FetchResult> => {
+    if (!value) {
+        return removeGqlConfig(name);
+    }
+
+    return cy.apolloClient().apollo({
+        mutation: gql`mutation setConfig($pid: String!, $name: String!, $value: String!) {
+            admin {
+                jahia {
+                    configuration(pid: $pid identifier: "default") {
+                        value(name: $name value: $value)
+                    }
+                }
+            }
+        }`,
+        variables: {pid, name, value}
+    });
+};
+
+export const removeGqlConfig = (name: string) : Chainable<ApolloQueryResult<any> | FetchResult> => {
+    return cy.apolloClient().apollo({
+        mutation: gql`mutation removeConfig($pid: String!, $name: String!) {
+            admin {
+                jahia {
+                    configuration(pid: $pid identifier: "default") {
+                        remove(name: $name)
+                    }
+                }
+            }
+        }`,
+        variables: {pid, name}
+    });
+};
+
+export const getGqlConfig = (name: string) : Chainable<string> => {
+    return cy.apolloClient().apollo({
+        query: gql`query getConfig($pid: String!, $name: String!) {
+            admin {
+                jahia {
+                    configuration(pid: $pid, identifier: "default") {
+                        value(name: $name)
+                    }
+                }
+            }
+        }`,
+        variables: {pid, name}
+    }).then(result => result?.data.admin.jahia.configuration.value);
+};

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,7 +5,6 @@ services:
         container_name: jahia
         environment:
             SUPER_USER_PASSWORD: ${SUPER_USER_PASSWORD}
-            JAHIA_PROPERTIES: '"introspectionCheckEnabled":"true"'
             MAX_RAM_PERCENTAGE: 95
             JPDA: "true"
         ports:


### PR DESCRIPTION
### Description

Refactoring and moving the `introspectionCheckEnabled` property from jahia.properties https://github.com/Jahia/jahia-private/pull/4526 to graphql OSGi config.

Introspection check is enabled if one of the gql configurations have the property enabled. 

This also means that to disable, users will have to make sure none of the graphql configurations have the property enabled.

#### Misc 

Remove `@typescript-eslint/no-explicit-any` in cypress tests by default instead of specifying on each file. (It's part of apollo return type definition)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
