### PR TITLE
test: Check that GraphQL workspace loads correctly

### DIFF
--- a/tests/cypress/e2e/tools/graphqlWorkspace.cy.ts
+++ b/tests/cypress/e2e/tools/graphqlWorkspace.cy.ts
@@ -1,6 +1,6 @@
 describe('GraphQL Workspace tests', () => {
     const GRAPHQL_WORKSPACE_URL = '/modules/graphql-dxm-provider/tools/graphql-workspace.jsp';
-    beforeEach('reset default value', () => {
+    beforeEach('prerequisites', () => {
         cy.login();
     });
 


### PR DESCRIPTION
### Description
Following the issue we had with `node-polyfill-webpack-plugin` (see https://github.com/Jahia/graphql-core/pull/560 for the fix), adding a Cypress test to validate that GraphQL workspace loads successfully.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
