### PR TITLE
test: fix system.cy.ts runtime name check

### DIFF
--- a/tests/cypress/e2e/api/admin/system.cy.ts
+++ b/tests/cypress/e2e/api/admin/system.cy.ts
@@ -1,8 +1,3 @@
-
-/* eslint max-nested-callbacks: ["error", 5] */
-import {getJahiaVersion} from '@jahia/cypress';
-import {compare} from 'compare-versions';
-
 describe('Test admin jahia system endpoint', () => {
     it('Gets system details', () => {
         cy.apollo({
@@ -12,17 +7,11 @@ describe('Test admin jahia system endpoint', () => {
             expect(response.data.admin.jahia.system.os.architecture.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.os.version.length).to.greaterThan(3);
 
-            getJahiaVersion().then(jahiaVersion => {
-                cy.log(JSON.stringify(jahiaVersion)).then(() => {
-                    // Jahia 8.2.1 and 8.2.2 are using GraalVM, the rest of the versions are using OpenJDK
-                    const jahiaVersionTrimmed = jahiaVersion.release.replace('-SNAPSHOT', '');
-                    if (compare(jahiaVersionTrimmed, '8.2.1', '=') || compare(jahiaVersionTrimmed, '8.2.2', '=')) {
-                        expect(response.data.admin.jahia.system.java.runtimeName).to.equal('Java(TM) SE Runtime Environment');
-                    } else {
-                        expect(response.data.admin.jahia.system.java.runtimeName).to.equal('OpenJDK Runtime Environment');
-                    }
-                });
-            });
+            const runtimeName = response.data.admin.jahia.system.java.runtimeName;
+            expect(runtimeName).to.satisfy(
+                (name: string) => name?.includes('Java') || name?.includes('OpenJDK'),
+                'Runtime name should contain either Java or OpenJDK'
+            );
             expect(response.data.admin.jahia.system.java.runtimeVersion.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendor.length).to.greaterThan(3);
             expect(response.data.admin.jahia.system.java.vendorVersion.length).to.greaterThan(3);

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,6 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "babel-plugin-istanbul": "^6.1.1",
-    "compare-versions": "^6.1.1",
     "cross-fetch": "^3.1.4",
     "cypress": "^15.7.0",
     "cypress-file-upload": "^5.0.8",


### PR DESCRIPTION
### Description

From discussion https://jahia.slack.com/archives/CDTMU869X/p1766155731138479?thread_ts=1766155606.327829&cid=CDTMU869X we decided to loosen up checking requirements for the runtime system to avoid breaking this test whenever JDKs are updated/switched.

We now loosely check if it contains one of the keywords "Java" or "OpenJDK" in the runtime name to make it compatible, in case string description changes on an upgrade.

We also remove `compare-versions` from devDependencies as it's not used anymore in our code, but no changes in yarn.lock as it's a transitive dependency in our other dependencies.



### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
