### PR TITLE
fix: Update XML import content type check in GqlJcrMutationSupport

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrMutationSupport.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrMutationSupport.java
@@ -197,6 +197,7 @@ public class GqlJcrMutationSupport {
                         FileUtils.deleteQuietly(fileToImport);
                     }
                     break;
+                case "application/xml":
                 case "text/xml":
                     importExportBaseService.importXML(node.getPath(), part.getInputStream(), rootBehaviour);
                     break;

--- a/tests/cypress/e2e/api/jcr/importContent.cy.ts
+++ b/tests/cypress/e2e/api/jcr/importContent.cy.ts
@@ -1,0 +1,41 @@
+import {createSite, deleteNode, deleteSite} from '@jahia/cypress';
+import {importContent} from '../../../fixtures/jcr/import';
+import gql from 'graphql-tag';
+
+describe('Test JCR import API', () => {
+    const siteKey = 'importTestSite';
+
+    before('setup', () => {
+        createSite(siteKey);
+    });
+
+    after('cleanup', () => {
+        deleteSite(siteKey);
+    });
+
+    const importXml = (mimeType: string) => {
+        importContent(`/sites/${siteKey}/contents`, 'jcr/import/rich-text.xml', mimeType)
+            .then(response => {
+                expect(response.data?.jcr.importContent, 'import should have returned success boolean').to.be.true;
+            });
+        cy.waitUntil(
+            () => {
+                return cy.apollo({
+                    query: gql`query findImportContent {
+                        jcr { nodeByPath(path: "/sites/${siteKey}/contents/rich-text") {uuid}}
+                    }`
+                }).then(response => Boolean(response.data.jcr.nodeByPath.uuid));
+            },
+            {timeout: 30000, interval: 1000}
+        );
+        deleteNode(`/sites/${siteKey}/contents/rich-text`);
+    };
+
+    it('imports content with "application/xml" mimetype', () => {
+        importXml('application/xml');
+    });
+
+    it('imports content with "text/xml" mimetype', () => {
+        importXml('text/xml');
+    });
+});

--- a/tests/cypress/fixtures/jcr/import/importContent.graphql
+++ b/tests/cypress/fixtures/jcr/import/importContent.graphql
@@ -1,0 +1,9 @@
+mutation importContent($path: String!, $file: String!, $rootBehaviour: Int! = 1) {
+    jcr {
+        importContent(
+            parentPathOrId: $path
+            file: $file
+            rootBehaviour: $rootBehaviour
+        )
+    }
+}

--- a/tests/cypress/fixtures/jcr/import/index.ts
+++ b/tests/cypress/fixtures/jcr/import/index.ts
@@ -1,0 +1,17 @@
+
+export function importContent(parentPath: string, fixtureFile: string, mimeType: string) {
+    const filename = fixtureFile.split('/').pop();
+    return cy.fixture(fixtureFile, 'binary').then(binaryFile => {
+        // Convert the file base64 string to a blob
+        const blob = Cypress.Blob.binaryStringToBlob(binaryFile, mimeType);
+        const file = new File([blob], filename, {type: blob.type});
+
+        return cy.apollo({
+            mutationFile: 'jcr/import/importContent.graphql',
+            variables: {
+                path: parentPath,
+                file
+            }
+        });
+    });
+}

--- a/tests/cypress/fixtures/jcr/import/rich-text.xml
+++ b/tests/cypress/fixtures/jcr/import/rich-text.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rich-text xmlns:j="http://www.jahia.org/jahia/1.0"
+           xmlns:jcr="http://www.jcp.org/jcr/1.0"
+           j:lastPublished="2023-04-18T14:38:37.717+02:00"
+           j:lastPublishedBy="olive"
+           j:originWS="default"
+           j:published="true"
+           jcr:created="2023-04-12T18:04:18.750+02:00"
+           jcr:createdBy="isis"
+           jcr:lastModified="2023-04-12T18:04:18.804+02:00"
+           jcr:lastModifiedBy="isis"
+           jcr:primaryType="jnt:bigText">
+   <j:translation_en j:lastPublished="2023-04-18T14:38:37.717+02:00"
+                     j:lastPublishedBy="olive"
+                     j:published="true"
+                     jcr:language="en"
+                     jcr:lastModified="2023-04-18T14:38:04.945+02:00"
+                     jcr:lastModifiedBy="alice"
+                     jcr:primaryType="jnt:translation"
+                     text="&lt;p&gt;According to a 2017 report by the International Union for Conservation of Nature, there are an estimated 220 million owned cats and 480 million stray or feral cats worldwide. These numbers are subject to change and may vary depending on the methodology used for estimating cat populations.&lt;/p&gt;&#xA;"/>
+   <j:translation_fr j:lastPublished="2023-04-12T18:22:12.980+02:00"
+                     j:lastPublishedBy="olive"
+                     j:published="true"
+                     jcr:language="fr"
+                     jcr:lastModified="2023-04-12T18:04:39.617+02:00"
+                     jcr:lastModifiedBy="isis"
+                     jcr:primaryType="jnt:translation"
+                     text="&lt;p&gt;Selon un rapport de 2017 de l&amp;#39;Union internationale pour la conservation de la nature, il y aurait environ 220 millions de chats domestiques et 480 millions de chats errants ou f&amp;eacute;raux dans le monde. Ces chiffres sont susceptibles de changer et peuvent varier en fonction de la m&amp;eacute;thodologie utilis&amp;eacute;e pour estimer les populations de chats.&lt;/p&gt;&#xA;"/>
+</rich-text>

--- a/tests/package.json
+++ b/tests/package.json
@@ -17,7 +17,7 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-terminal-report": "^7.1.0",
-    "cypress-wait-until": "^3.0.1",
+    "cypress-wait-until": "^3.0.2",
     "date-fns": "^2.25.0",
     "diff": "^5.0.0",
     "eslint": "8.57.1",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -2592,10 +2592,10 @@ cypress-terminal-report@^7.1.0:
     process "^0.11.10"
     superstruct "0.14.2"
 
-cypress-wait-until@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-3.0.1.tgz#6a697a600f4fb8cd2897489a15fda77c9857abec"
-  integrity sha512-kpoa8yL6Bi/JNsThGBbrrm7g4SNzYyBUv9M5pF6/NTVm/ClY0HnJzeuWnHiAUZKIZ5l86Oedb12wQyjx7/CWPg==
+cypress-wait-until@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-3.0.2.tgz#c90dddfa4c46a2c422f5b91d486531c560bae46e"
+  integrity sha512-iemies796dD5CgjG5kV0MnpEmKSH+s7O83ZoJLVzuVbZmm4lheMsZqAVT73hlMx4QlkwhxbyUzhOBUOZwoOe0w==
 
 cypress@^15.7.0:
   version "15.7.0"


### PR DESCRIPTION
### Description

Issue when importing content in xml format in some browsers. Specifically in (newer versions) of Chrome, it uses `application/xml` as mimetype instead of the legacy `text/xml`. 

Add support for the new standard generic xml mimetype.

Added test for xml import content with the different mimetypes.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
