### PR TITLE
fix: Add permission check for grant, revoke role APIs

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
@@ -25,6 +25,7 @@ import org.jahia.modules.graphql.provider.dxm.acl.service.JahiaAclService;
 import org.jahia.modules.graphql.provider.dxm.image.GqlJcrImageTransformMutation;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
 import org.jahia.modules.graphql.provider.dxm.predicate.PredicateHelper;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.modules.graphql.provider.dxm.user.PrincipalType;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -537,6 +538,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
 
     @GraphQLField
     @GraphQLDescription("Grant role permissions to specified principal user/group for the given node")
+    @GraphQLRequiresPermission(value = "adminRoles")
     public boolean grantRoles(
             @GraphQLName("roleNames") @GraphQLDescription("Roles to grant user/group for this node") @GraphQLNonNull List<String> roleNames,
             @GraphQLName("principalType") @GraphQLDescription("Type of principal (user/group) specified") @GraphQLNonNull PrincipalType principalType,
@@ -548,6 +550,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
 
     @GraphQLField
     @GraphQLDescription("Remove/deny roles to specified principal user/group for the given node")
+    @GraphQLRequiresPermission(value = "adminRoles")
     public boolean revokeRoles(
             @GraphQLName("roleNames") @GraphQLDescription("Roles to grant user/group for this node") @GraphQLNonNull List<String> roleNames,
             @GraphQLName("principalType") @GraphQLDescription("Type of principal (user/group) specified") @GraphQLNonNull PrincipalType principalType,

--- a/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
+++ b/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
@@ -1,0 +1,66 @@
+import {createSite, createUser, deleteSite, deleteUser} from '@jahia/cypress';
+import {grantUserRole} from '../../../fixtures/acl';
+
+describe('API permissions test', () => {
+    const siteKey = 'roleSite';
+    const adminRoleUser = {username: 'adminRoleUser', password: 'password'};
+    const editorUser = {username: 'editorUser', password: 'password'};
+    const testUser = {username: 'testUser', password: 'password'};
+
+    before(() => {
+        createSite(siteKey);
+
+        // Set up users
+        [adminRoleUser, editorUser, testUser]
+            .forEach(({username, password}) => createUser(username, password));
+        grantUserRole(`/sites/${siteKey}`, 'editor', editorUser.username);
+        // Server-administrator role has required adminRoles permission enabled
+        grantUserRole('/', 'server-administrator', adminRoleUser.username);
+    });
+
+    after(() => {
+        [adminRoleUser, editorUser, testUser]
+            .forEach(({username}) => deleteUser(username));
+        deleteSite(siteKey);
+    });
+
+    const rolesApiCall = (apiUser, mutationFile, variables) => {
+        return cy.apolloClient(apiUser)
+            .apollo({mutationFile, variables});
+    };
+
+    it('checks proper permission to grant/revoke roles', () => {
+        const gqlParams = {
+            pathOrId: `/sites/${siteKey}/files`,
+            roles: ['editor'],
+            pType: 'USER',
+            pName: testUser.username
+        };
+
+        cy.log('Grant user should fail without proper permission');
+        rolesApiCall(editorUser, 'acl/grantRoles.graphql', gqlParams)
+            .should(resp => {
+                expect(resp.graphQLErrors, 'Errors exist').to.have.length(1);
+                expect(resp.graphQLErrors[0].errorType, 'Grant role request denied').to.equal('GqlAccessDeniedException');
+            });
+
+        cy.log('Grant user should succeed with adminRoles permission');
+        rolesApiCall(adminRoleUser, 'acl/grantRoles.graphql', gqlParams)
+            .should(resp => {
+                expect(resp?.data?.jcr?.mutateNode?.grantRoles, 'Grant role request OK').to.be.true;
+            });
+
+        cy.log('Revoke user should fail without proper permission');
+        rolesApiCall(editorUser, 'acl/revokeRoles.graphql', gqlParams).should(resp => {
+            expect(resp.graphQLErrors, 'Errors exist').to.have.length(1);
+            expect(resp.graphQLErrors[0].errorType, 'Grant role request denied').to.equal(
+                'GqlAccessDeniedException'
+            );
+        });
+
+        cy.log('Revoke user should succeed with adminRoles permission');
+        rolesApiCall(adminRoleUser, 'acl/revokeRoles.graphql', gqlParams).should(resp => {
+            expect(resp?.data?.jcr?.mutateNode?.revokeRoles, 'Grant role request OK').to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
### Description

Add permission check for `adminRoles` permission to grant, revoke role APIs.

Add cypress test.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
