### PR TITLE
fix: Add permission check for grant, revoke role APIs

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeMutation.java
@@ -27,6 +27,7 @@ import org.jahia.modules.graphql.provider.dxm.acl.service.JahiaAclService;
 import org.jahia.modules.graphql.provider.dxm.image.GqlJcrImageTransformMutation;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
 import org.jahia.modules.graphql.provider.dxm.predicate.PredicateHelper;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.modules.graphql.provider.dxm.user.PrincipalType;
 import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -533,6 +534,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
 
     @GraphQLField
     @GraphQLDescription("Grant role permissions to specified principal user/group for the given node")
+    @GraphQLRequiresPermission(value = "adminRoles")
     public boolean grantRoles(
             @GraphQLName("roleNames") @GraphQLDescription("Roles to grant user/group for this node") @GraphQLNonNull List<String> roleNames,
             @GraphQLName("principalType") @GraphQLDescription("Type of principal (user/group) specified") @GraphQLNonNull PrincipalType principalType,
@@ -544,6 +546,7 @@ public class GqlJcrNodeMutation extends GqlJcrMutationSupport {
 
     @GraphQLField
     @GraphQLDescription("Remove/deny roles to specified principal user/group for the given node")
+    @GraphQLRequiresPermission(value = "adminRoles")
     public boolean revokeRoles(
             @GraphQLName("roleNames") @GraphQLDescription("Roles to grant user/group for this node") @GraphQLNonNull List<String> roleNames,
             @GraphQLName("principalType") @GraphQLDescription("Type of principal (user/group) specified") @GraphQLNonNull PrincipalType principalType,

--- a/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
+++ b/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
@@ -22,6 +22,7 @@ describe('roles API permissions test', () => {
         [adminRoleUser, editorUser, testUser]
             .forEach(({username}) => deleteUser(username));
         deleteSite(siteKey);
+        cy.executeGroovy('groovy/flushCache.groovy', {CACHE_NAME: 'org.jahia.sitesService.sitesListCache'});
     });
 
     const rolesApiCall = (apiUser, mutationFile, variables) => {

--- a/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
+++ b/tests/cypress/e2e/api/acl/grantRevokePermissions.cy.ts
@@ -1,0 +1,66 @@
+import {createSite, createUser, deleteSite, deleteUser} from '@jahia/cypress';
+import {grantUserRole} from '../../../fixtures/acl';
+
+describe('roles API permissions test', () => {
+    const adminRoleUser = {username: 'adminRoleUser', password: 'password'};
+    const editorUser = {username: 'editorUser', password: 'password'};
+    const testUser = {username: 'testUser', password: 'password'};
+    const siteKey = 'roleSite';
+
+    before(() => {
+        createSite(siteKey);
+
+        // Set up users
+        [adminRoleUser, editorUser, testUser]
+            .forEach(({username, password}) => createUser(username, password));
+        grantUserRole(`/sites/${siteKey}`, 'editor', editorUser.username);
+        // Server-administrator role has required adminRoles permission enabled
+        grantUserRole('/', 'server-administrator', adminRoleUser.username);
+    });
+
+    after(() => {
+        [adminRoleUser, editorUser, testUser]
+            .forEach(({username}) => deleteUser(username));
+        deleteSite(siteKey);
+    });
+
+    const rolesApiCall = (apiUser, mutationFile, variables) => {
+        return cy.apolloClient(apiUser)
+            .apollo({mutationFile, variables});
+    };
+
+    it('checks proper permission to grant/revoke roles', () => {
+        const gqlParams = {
+            pathOrId: `/sites/${siteKey}/files`,
+            roles: ['editor'],
+            pType: 'USER',
+            pName: testUser.username
+        };
+
+        cy.log('Grant user should fail without proper permission');
+        rolesApiCall(editorUser, 'acl/grantRoles.graphql', gqlParams)
+            .should(resp => {
+                expect(resp.graphQLErrors, 'Errors exist').to.have.length(1);
+                expect(resp.graphQLErrors[0].errorType, 'Grant role request denied').to.equal('GqlAccessDeniedException');
+            });
+
+        cy.log('Grant user should succeed with adminRoles permission');
+        rolesApiCall(adminRoleUser, 'acl/grantRoles.graphql', gqlParams)
+            .should(resp => {
+                expect(resp?.data?.jcr?.mutateNode?.grantRoles, 'Grant role request OK').to.be.true;
+            });
+
+        cy.log('Revoke user should fail without proper permission');
+        rolesApiCall(editorUser, 'acl/revokeRoles.graphql', gqlParams).should(resp => {
+            expect(resp.graphQLErrors, 'Errors exist').to.have.length(1);
+            expect(resp.graphQLErrors[0].errorType, 'Grant role request denied').to.equal(
+                'GqlAccessDeniedException'
+            );
+        });
+
+        cy.log('Revoke user should succeed with adminRoles permission');
+        rolesApiCall(adminRoleUser, 'acl/revokeRoles.graphql', gqlParams).should(resp => {
+            expect(resp?.data?.jcr?.mutateNode?.revokeRoles, 'Grant role request OK').to.be.true;
+        });
+    });
+});

--- a/tests/cypress/e2e/api/admin/config.cy.ts
+++ b/tests/cypress/e2e/api/admin/config.cy.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 
 describe('admin.configuration', () => {
     before('load graphql file and create test dataset', () => {
-        cy.runProvisioningScript({fileName: 'admin/createConfig.json'});
+        cy.runProvisioningScript({script: {fileName: 'admin/createConfig.json', type: 'application/json'}});
     });
 
     function readConfig(variables) {

--- a/tests/cypress/e2e/api/admin/users.cy.ts
+++ b/tests/cypress/e2e/api/admin/users.cy.ts
@@ -2,7 +2,7 @@
 
 describe('Test admin users endpont', () => {
     before('load graphql file', () => {
-        cy.runProvisioningScript({fileName: 'admin/addLDAPConfigurationFile.json'});
+        cy.runProvisioningScript({script: {fileName: 'admin/addLDAPConfigurationFile.json', type: 'application/json'}});
         cy.login();
         cy.visit('/cms/adminframe/default/en/settings.manageUsers.html');
         cy.repeatUntil('td:contains("Filibert Alfred")', {attempts: 10});

--- a/tests/cypress/fixtures/groovy/flushCache.groovy
+++ b/tests/cypress/fixtures/groovy/flushCache.groovy
@@ -1,0 +1,3 @@
+import org.jahia.services.cache.CacheHelper
+
+CacheHelper.flushEhcacheByName("CACHE_NAME")

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "cypress",
   "devDependencies": {
-    "@apollo/client": "^3.4.16",
+    "@apollo/client": "^3.14.0",
     "@cypress/code-coverage": "^3.9.11",
     "@cypress/webpack-preprocessor": "^5.9.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@jahia/cypress": "3.25.0",
+    "@jahia/cypress": "^6.4.3",
     "@jahia/eslint-config": "^2.1.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -15,7 +15,26 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.4.16", "@apollo/client@^3.4.9":
+"@apollo/client@^3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.14.0.tgz#eda34b85ee03c6c0828ba21782419c8699feaf0b"
+  integrity sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.18.0"
+    prop-types "^15.7.2"
+    rehackt "^0.1.0"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
+"@apollo/client@^3.4.9":
   version "3.4.16"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.16.tgz#67090d5655aa843fa64d26f1913315e384a5fa0f"
   integrity sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==
@@ -1894,6 +1913,11 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"
@@ -1936,10 +1960,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/cypress@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-3.25.0.tgz#c0dd056aca5f1b19b18d50ae0f7ee1082e5badc7"
-  integrity sha512-ENASAWSuUNzt3WQc8mMdLJsGkOKnc8TkuSPH7BbNqfOk+hq2W7r9SgMjK9tXUwpMgLRhyO+ViZAI3t2UGnxRuQ==
+"@jahia/cypress@^6.4.3":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-6.5.0.tgz#473e5bb7babc5cc45ecf4c655a94f770b6d7f23c"
+  integrity sha512-zMCl3ecOrWzAZKf2Faw80l50T5ahd+S0HkU21mVg6G6zYU7igD+QVKa/uhIGKK0xBRJAqvX8lE7atOCHIHOS3Q==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"
@@ -2532,10 +2556,24 @@
     "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
+"@wry/caches@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wry/caches/-/caches-1.0.1.tgz#8641fd3b6e09230b86ce8b93558d44cf1ece7e52"
+  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
+  dependencies:
+    tslib "^2.3.0"
+
 "@wry/context@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
   integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/context@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.4.tgz#e32d750fa075955c4ab2cfb8c48095e1d42d5990"
+  integrity sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==
   dependencies:
     tslib "^2.3.0"
 
@@ -2546,10 +2584,24 @@
   dependencies:
     tslib "^2.3.0"
 
+"@wry/equality@^0.5.6":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.7.tgz#72ec1a73760943d439d56b7b1e9985aec5d497bb"
+  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
+  dependencies:
+    tslib "^2.3.0"
+
 "@wry/trie@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
   integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.5.0.tgz#11e783f3a53f6e4cd1d42d2d1323f5bc3fa99c94"
+  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
   dependencies:
     tslib "^2.3.0"
 
@@ -5419,6 +5471,13 @@ graphql-tag@^2.11.0, graphql-tag@^2.12.3, graphql-tag@^2.12.5:
   dependencies:
     tslib "^2.1.0"
 
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql@^15.5.0, graphql@^15.7.0:
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.0.tgz#caace26caf9b875b80982c45db58765d8a060e3e"
@@ -7226,6 +7285,16 @@ optimism@^0.16.1:
     "@wry/context" "^0.6.0"
     "@wry/trie" "^0.3.0"
 
+optimism@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.18.1.tgz#5cf16847921413dbb0ac809907370388b9c6335f"
+  integrity sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==
+  dependencies:
+    "@wry/caches" "^1.0.0"
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.5.0"
+    tslib "^2.3.0"
+
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
@@ -7865,6 +7934,11 @@ regjsparser@^0.9.1:
   integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
   dependencies:
     jsesc "~0.5.0"
+
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
 
 release-zalgo@^1.0.0:
   version "1.0.0"
@@ -8812,6 +8886,13 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-invariant@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
@@ -9527,6 +9608,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
 
 zen-observable-ts@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Description

2_x backport for PR https://github.com/Jahia/graphql-core/pull/575

> Add permission check for adminRoles permission to grant, revoke role APIs.
> 
> Add cypress test.

Had to do some updates to package.json, and related `cy.runProvisioningScript()` changes as it seems the graphql response structure isn't the same as before. 

Also had to add test workaround for issue https://github.com/Jahia/graphql-core/pull/465.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
