### PR TITLE
chore: Add sample permission restriction methods for GQL endpoints

### DIFF
--- a/graphql-extension-example/pom.xml
+++ b/graphql-extension-example/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <jahia-module-signature>MCwCFH0UchFrXi5LEyh14Dzkt7Zdl1LVAhQw7yQZMgQbXfYbKKSAxrxF7iE2/w==</jahia-module-signature>
-        <jahia-depends>default,graphql-dxm-provider</jahia-depends>
+        <jahia-depends>default,news,graphql-dxm-provider</jahia-depends>
     </properties>
 
     <dependencies>

--- a/graphql-extension-example/src/main/import/permissions.xml
+++ b/graphql-extension-example/src/main/import/permissions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions jcr:primaryType="jnt:permission"
+             xmlns:jcr="http://www.jcp.org/jcr/1.0"
+             xmlns:j="http://www.jahia.org/jahia/1.0"
+             xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+    <developerTools jcr:primaryType="jnt:permission">
+        <myApiAdmin jcr:primaryType="jnt:permission"/>
+    </developerTools>
+</permissions>

--- a/graphql-extension-example/src/main/java/org/jahia/modules/graphql/provider/dxm/extensions/JCRNodeExtensions.java
+++ b/graphql-extension-example/src/main/java/org/jahia/modules/graphql/provider/dxm/extensions/JCRNodeExtensions.java
@@ -21,6 +21,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 
 @GraphQLTypeExtension(GqlJcrNode.class)
 public class JCRNodeExtensions {
@@ -32,8 +33,32 @@ public class JCRNodeExtensions {
     }
 
     @GraphQLField
-    @GraphQLDescription("Sample extension") 
+    @GraphQLDescription("Sample extension")
     public String testExtension(@GraphQLName("arg") @GraphQLDescription("Sample extension argument") String arg) {
         return "test " + node.getName() + " - " + arg;
+    }
+
+    /**
+     * To allow access to this endpoint, add user to a server-type role e.g. web designer role,
+     * and enable myApiAdmin permissions
+     */
+    @GraphQLField
+    @GraphQLDescription("Sample extension")
+    @GraphQLRequiresPermission("myApiAdmin")
+    public String testRequiresPermission(@GraphQLName("arg") @GraphQLDescription("Sample extension argument") String arg) {
+        return "protected endpoint:  " + node.getName() + " - " + arg;
+    }
+
+    /**
+     * This endpoint is restricted using OSGi configuration entry:
+     * permission.JCRNode.testPermissionConfiguration = myApiAdmin
+     *
+     * To allow access to this endpoint, add user to a server-type role e.g. web designer role,
+     * and enable myApiAdmin permissions
+     */
+    @GraphQLField
+    @GraphQLDescription("Sample extension")
+    public String testPermissionConfiguration(@GraphQLName("arg") @GraphQLDescription("Sample extension argument") String arg) {
+        return "protected endpoint:  " + node.getName() + " - " + arg;
     }
 }

--- a/graphql-extension-example/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-example.cfg
+++ b/graphql-extension-example/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-example.cfg
@@ -1,0 +1,31 @@
+# default configuration - won't be overriden
+#
+# Config file for GraphQL dxm provider.
+#
+
+#
+# List of permissions to be checked for specific GraphQL types and fields.
+# Format is like: permission.{TYPE}.{FIELD} = {PERMISSION}
+# Where:
+#   {TYPE}:         is the GraphQL type ( ex: Query, JCRNode, GenericJCRNode, etc.. )
+#                   Inheritance is possible between types ( ex: GenericJCRNode inherit of all JCRNode permission properties ),
+#                   unless GenericJCRNode redefine permission properties for some specific fields.
+#                   example of inheritance and override:
+#
+#                   permission.JCRNode.* = graphQlNodeReadPermission
+#                   permission.GenericJCRNode.getSite = graphQlSiteReadPermission
+#
+#   {FIELD}:        is the GraphQL field from the previous type, wildcard is allowed if you want to restrict access
+#                   to all the fields of a specific type. Combination of named field and wildcard is possible, a named field
+#                   will always override the wildcard permission.
+#                   For example, if we want to restrict all the Query type fields using one permission for all the fields, and
+#                   a different permission for a specific field:
+#
+#                   permission.Query.* = graphQLQueryAccessPermission
+#                   permission.Query.getNodesByPath = graphQLNodesByPathPermission
+#
+#   {PERMISSION}:   is the permission name that will be use to check the access to previously defined type and field(s)
+#                   permissions are always checked on the root JCR node.
+#
+# permission.JCRQuery.* = jcr:read
+permission.JCRNode.testPermissionConfiguration = myApiAdmin


### PR DESCRIPTION
### Description

Add sample usage/setup of adding permission restriction through `@GraphQLRequiresPermission` annotations and config properties methods.

I also added news module as a dependency for the module in `jahia-depends` as it's required for SDL definitions https://github.com/Jahia/graphql-core/blob/master/graphql-extension-example/src/main/resources/META-INF/graphql-extension.sdl#L2. It's unrelated to permissions but it's an issue I came across while testing, so I added the fix.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
