### PR TITLE
test: Fix ACL inheritance check

### DIFF
--- a/tests/cypress/e2e/api/acl/aclEntries.cy.ts
+++ b/tests/cypress/e2e/api/acl/aclEntries.cy.ts
@@ -43,7 +43,7 @@ describe('Test ACL/ACE query endpoint', () => {
             const aclEntry = getRole(acl.aclEntries, 'guest', 'reader');
             expect(aclEntry, `Anne has editor-in-chief role for ${path}`).to.be.not.undefined;
             expect(aclEntry.inherited).to.be.true;
-            expect(aclEntry.inheritedFrom.path).equals('/');
+            expect(aclEntry.inheritedFrom.path).equals('/sites');
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/Jahia/graphql-core/issues/601.
Fixes https://github.com/Jahia/jahia-private/issues/4843.

### Description
Since https://github.com/Jahia/jahia-private/issues/4843, the guest ACLs for a node like `/sites/digitall/files/images/placeholder.jpg` are now inherited from `/sites` .


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
