### PR TITLE
test: Add support for both Jahia release and snapshot versions in aclEntries test

### DIFF
--- a/tests/cypress/e2e/api/acl/aclEntries.cy.ts
+++ b/tests/cypress/e2e/api/acl/aclEntries.cy.ts
@@ -1,5 +1,7 @@
 
 import {getAclEntries} from '../../../fixtures/acl';
+import {getJahiaVersion} from '@jahia/cypress';
+import {compare} from 'compare-versions';
 
 describe('Test ACL/ACE query endpoint', () => {
     const parentPath = '/sites/digitall/files/images';
@@ -38,12 +40,20 @@ describe('Test ACL/ACE query endpoint', () => {
     });
 
     it(`Guest user has reader role for ${path}`, () => {
-        getAclEntries(path).should(resp => {
+        getAclEntries(path).then(resp => {
             const acl = resp?.data?.jcr?.nodeByPath?.acl;
             const aclEntry = getRole(acl.aclEntries, 'guest', 'reader');
-            expect(aclEntry, `Anne has editor-in-chief role for ${path}`).to.be.not.undefined;
+            expect(aclEntry, `Guest user has reader role for ${path}`).to.be.not.undefined;
             expect(aclEntry.inherited).to.be.true;
-            expect(aclEntry.inheritedFrom.path).equals('/sites');
+
+            /* Inheritance from /sites only supported >= 8.2.4.0.
+             * Before, it was defined on root node `/`
+             * https://github.com/Jahia/jahia-private/pull/4893 */
+            getJahiaVersion().then(jahiaVersion => {
+                const isSupported = compare(jahiaVersion.release.replace('-SNAPSHOT', ''), '8.2.4', '>=');
+                const expectedValue = isSupported ? '/sites' : '/';
+                expect(aclEntry.inheritedFrom.path, `ACL entry should be inherited from ${expectedValue}`).equals(expectedValue);
+            });
         });
     });
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "babel-plugin-istanbul": "^6.1.1",
+    "compare-versions": "^6.1.1",
     "cross-fetch": "^3.1.4",
     "cypress": "^15.7.0",
     "cypress-file-upload": "^5.0.8",


### PR DESCRIPTION
### Description

Adjustments done based on recent snapshot changes https://github.com/Jahia/graphql-core/pull/602

But need to add condition to also make it work for Nightly release runs.

