### PR TITLE
feat: Add user metadata extension to JCR Node API

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentation.java
@@ -15,6 +15,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.instrumentation;
 
+import graphql.ExecutionResult;
 import graphql.execution.ExecutionContext;
 import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
@@ -25,11 +26,13 @@ import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.jahia.modules.graphql.provider.dxm.osgi.OSGIServiceInjectorDataFetcher;
 import org.jahia.modules.graphql.provider.dxm.security.GqlJcrPermissionChecker;
 import org.jahia.modules.graphql.provider.dxm.security.GqlJcrPermissionDataFetcher;
+import org.jahia.modules.graphql.provider.dxm.user.UserResolutionCache;
 import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * JCR instrumentation implementation
@@ -82,5 +85,11 @@ public class JCRInstrumentation extends SimpleInstrumentation {
             GqlJcrPermissionChecker.configureIntrospectionFromPermissions(executionContext.getGraphQLContext());
         }
         return executionContext;
+    }
+
+    @Override
+    public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
+        UserResolutionCache.clear();
+        return super.instrumentExecutionResult(executionResult, parameters);
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.user;
+
+import graphql.annotations.annotationTypes.*;
+import org.jahia.exceptions.JahiaRuntimeException;
+import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
+import org.jahia.modules.graphql.provider.dxm.node.NodeHelper;
+import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
+import org.jahia.osgi.BundleUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.decorator.JCRSiteNode;
+import org.jahia.services.content.decorator.JCRUserNode;
+import org.jahia.services.usermanager.JahiaUserManagerService;
+
+import javax.inject.Inject;
+import javax.jcr.RepositoryException;
+
+/**
+ * User metadata extensions for the JCR node.
+ *
+ * Adds resolved {@link GqlUser} fields for the common user-tracking properties on a JCR node
+ * (createdBy, lastModifiedBy, lastPublishedBy, deletedBy), so that user display names, first names,
+ * last names and email addresses are available in the same GraphQL request as the node data.
+ */
+@GraphQLTypeExtension(GqlJcrNode.class)
+public class UserJCRNodeExtension {
+
+    @Inject
+    @GraphQLOsgiService
+    private JahiaUserManagerService userManagerService;
+    private final GqlJcrNode gqlJcrNode;
+
+    public UserJCRNodeExtension(GqlJcrNode node) {
+        this.gqlJcrNode = node;
+    }
+
+    /**
+     * Resolves the user who created this node (jcr:createdBy).
+     *
+     * @return GqlUser for the creator, or null if the property is absent or the account no longer exists
+     */
+    @GraphQLField
+    @GraphQLDescription("User who created this node (resolved from jcr:createdBy)")
+    public GqlUser getCreatedByUser() {
+        try {
+            JCRNodeWrapper node = gqlJcrNode.getNode();
+            if (!node.hasProperty("jcr:createdBy")) {
+                return null;
+            }
+            String username = node.getProperty("jcr:createdBy").getString();
+            return resolveUser(username, node);
+        } catch (RepositoryException e) {
+            throw new JahiaRuntimeException(e);
+        }
+    }
+
+    /**
+     * Resolves the user who last modified this node (jcr:lastModifiedBy) in the given language.
+     *
+     * @param language Content language (required because jcr:lastModifiedBy is language-specific)
+     * @return GqlUser for the last modifier, or null if the property is absent or the account no longer exists
+     */
+    @GraphQLField
+    @GraphQLDescription("User who last modified this node (resolved from jcr:lastModifiedBy) for the given language")
+    public GqlUser getLastModifiedByUser(
+            @GraphQLName("language") @GraphQLNonNull @GraphQLDescription("Content language") String language) {
+        return resolveI18nUserProperty("jcr:lastModifiedBy", language);
+    }
+
+    /**
+     * Resolves the user who last published this node (j:lastPublishedBy) in the given language.
+     *
+     * @param language Content language (required because j:lastPublishedBy is language-specific)
+     * @return GqlUser for the last publisher, or null if the property is absent or the account no longer exists
+     */
+    @GraphQLField
+    @GraphQLDescription("User who last published this node (resolved from j:lastPublishedBy) for the given language")
+    public GqlUser getLastPublishedByUser(
+            @GraphQLName("language") @GraphQLNonNull @GraphQLDescription("Content language") String language) {
+        return resolveI18nUserProperty("j:lastPublishedBy", language);
+    }
+
+    /**
+     * Resolves the user who marked this node for deletion (j:deletionUser) in the given language.
+     *
+     * @param language Content language (required because j:deletionUser is language-specific)
+     * @return GqlUser for the deleting user, or null if the property is absent or the account no longer exists
+     */
+    @GraphQLField
+    @GraphQLDescription("User who marked this node for deletion (resolved from j:deletionUser) for the given language")
+    public GqlUser getDeletedByUser(
+            @GraphQLName("language") @GraphQLNonNull @GraphQLDescription("Content language") String language) {
+        return resolveI18nUserProperty("j:deletionUser", language);
+    }
+
+    /**
+     * Resolves the lock owner of this node (jcr:lockOwner).
+     *
+     * @return GqlUser for the lock owner, or null if the node is not locked or the account no longer exists
+     */
+    @GraphQLField
+    @GraphQLDescription("User who holds the lock on this node (resolved from jcr:lockOwner)")
+    public GqlUser getLockOwnerUser() {
+        try {
+            JCRNodeWrapper node = gqlJcrNode.getNode();
+            if (!node.hasProperty("jcr:lockOwner")) {
+                return null;
+            }
+            String username = node.getProperty("jcr:lockOwner").getString();
+            return resolveUser(username, node);
+        } catch (RepositoryException e) {
+            throw new JahiaRuntimeException(e);
+        }
+    }
+
+    // -- helpers --
+
+    private GqlUser resolveI18nUserProperty(String propertyName, String language) {
+        try {
+            JCRNodeWrapper i18nNode = NodeHelper.getNodeInLanguage(gqlJcrNode.getNode(), language);
+            if (!i18nNode.hasProperty(propertyName)) {
+                return null;
+            }
+            String username = i18nNode.getProperty(propertyName).getString();
+            return resolveUser(username, gqlJcrNode.getNode());
+        } catch (RepositoryException e) {
+            throw new JahiaRuntimeException(e);
+        }
+    }
+
+    private GqlUser resolveUser(String username, JCRNodeWrapper node) throws RepositoryException {
+        if (username == null || username.isEmpty()) {
+            return null;
+        }
+        if (userManagerService == null) {
+            userManagerService = BundleUtils.getOsgiService(JahiaUserManagerService.class, null);
+        }
+        String siteKey = getSiteKey(node);
+        JCRUserNode userNode = userManagerService.lookupUser(username, siteKey);
+        if (userNode == null) {
+            return null;
+        }
+        return new GqlUser(userNode.getJahiaUser());
+    }
+
+    private String getSiteKey(JCRNodeWrapper node) {
+        try {
+            JCRSiteNode site = node.getResolveSite();
+            return site != null ? site.getSiteKey() : null;
+        } catch (RepositoryException e) {
+            return null;
+        }
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
@@ -28,6 +28,7 @@ import org.jahia.services.usermanager.JahiaUserManagerService;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
+import java.util.Optional;
 
 /**
  * User metadata extensions for the JCR node.
@@ -146,15 +147,20 @@ public class UserJCRNodeExtension {
         if (username == null || username.isEmpty()) {
             return null;
         }
+        String siteKey = getSiteKey(node);
+
+        Optional<GqlUser> cached = UserResolutionCache.getIfPresent(username, siteKey);
+        if (cached != null) {
+            return cached.orElse(null);
+        }
+
         if (userManagerService == null) {
             userManagerService = BundleUtils.getOsgiService(JahiaUserManagerService.class, null);
         }
-        String siteKey = getSiteKey(node);
         JCRUserNode userNode = userManagerService.lookupUser(username, siteKey);
-        if (userNode == null) {
-            return null;
-        }
-        return new GqlUser(userNode.getJahiaUser());
+        GqlUser result = userNode != null ? new GqlUser(userNode.getJahiaUser()) : null;
+        UserResolutionCache.put(username, siteKey, result);
+        return result;
     }
 
     private String getSiteKey(JCRNodeWrapper node) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserJCRNodeExtension.java
@@ -20,15 +20,12 @@ import org.jahia.exceptions.JahiaRuntimeException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.node.NodeHelper;
 import org.jahia.modules.graphql.provider.dxm.osgi.annotations.GraphQLOsgiService;
-import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.decorator.JCRSiteNode;
-import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 
 import javax.inject.Inject;
 import javax.jcr.RepositoryException;
-import java.util.Optional;
 
 /**
  * User metadata extensions for the JCR node.
@@ -143,24 +140,9 @@ public class UserJCRNodeExtension {
         }
     }
 
-    private GqlUser resolveUser(String username, JCRNodeWrapper node) throws RepositoryException {
-        if (username == null || username.isEmpty()) {
-            return null;
-        }
+    private GqlUser resolveUser(String username, JCRNodeWrapper node) {
         String siteKey = getSiteKey(node);
-
-        Optional<GqlUser> cached = UserResolutionCache.getIfPresent(username, siteKey);
-        if (cached != null) {
-            return cached.orElse(null);
-        }
-
-        if (userManagerService == null) {
-            userManagerService = BundleUtils.getOsgiService(JahiaUserManagerService.class, null);
-        }
-        JCRUserNode userNode = userManagerService.lookupUser(username, siteKey);
-        GqlUser result = userNode != null ? new GqlUser(userNode.getJahiaUser()) : null;
-        UserResolutionCache.put(username, siteKey, result);
-        return result;
+        return UserResolutionCache.resolve(username, siteKey, userManagerService);
     }
 
     private String getSiteKey(JCRNodeWrapper node) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserResolutionCache.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserResolutionCache.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.user;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Request-scoped cache for resolved {@link GqlUser} objects.
+ *
+ * <p>A single GraphQL request may reference the same username many times across many JCR nodes
+ * (e.g., 50 content rows all last-modified by the same user). Without caching, each reference
+ * triggers a separate {@code JahiaUserManagerService.lookupUser()} call. This cache deduplicates
+ * those calls to at most one {@code lookupUser} per unique {@code (siteKey, username)} pair within
+ * a single GraphQL execution.
+ *
+ * <p>The cache is backed by a {@link ThreadLocal} and must be cleared at the end of each GraphQL
+ * execution via {@link #clear()} — this is done by
+ * {@code JCRInstrumentation.instrumentExecutionResult}.
+ *
+ * <p>{@code null} results (users that do not exist) are also cached as
+ * {@link Optional#empty()} so that repeated lookups for missing users do not issue redundant
+ * backend calls within the same request.
+ *
+ * <p>At the end of each request, an INFO log is emitted summarising the number of cache hits,
+ * misses, and unique users resolved. This can be used to assess cache effectiveness in production.
+ */
+public final class UserResolutionCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserResolutionCache.class);
+
+    private static final ThreadLocal<Map<String, Optional<GqlUser>>> CACHE =
+            ThreadLocal.withInitial(HashMap::new);
+
+    private static final ThreadLocal<int[]> STATS =
+            ThreadLocal.withInitial(() -> new int[2]); // [0]=hits, [1]=misses
+
+    private UserResolutionCache() {
+    }
+
+    /**
+     * Returns the cached user for {@code (username, siteKey)}, or {@code null} if not present.
+     * A return value of {@link Optional#empty()} means the user was looked up and does not exist.
+     *
+     * @param username the username to look up (never {@code null})
+     * @param siteKey  the site key, or {@code null} for global users
+     * @return the cached {@link Optional} entry, or {@code null} if not in cache
+     */
+    public static Optional<GqlUser> getIfPresent(String username, String siteKey) {
+        Optional<GqlUser> cached = CACHE.get().get(cacheKey(username, siteKey));
+        if (cached != null) {
+            STATS.get()[0]++;
+        } else {
+            STATS.get()[1]++;
+        }
+        return cached;
+    }
+
+    /**
+     * Stores a resolved user (or confirmed absence) in the request-scoped cache.
+     *
+     * @param username the username (never {@code null})
+     * @param siteKey  the site key, or {@code null} for global users
+     * @param user     the resolved user, or {@code null} if the user does not exist
+     */
+    public static void put(String username, String siteKey, GqlUser user) {
+        CACHE.get().put(cacheKey(username, siteKey), Optional.ofNullable(user));
+    }
+
+    /**
+     * Clears the request-scoped cache for the current thread and logs a cache effectiveness
+     * summary at INFO level.
+     * Must be called at the end of each GraphQL execution to prevent stale data leaking
+     * into subsequent requests on the same thread.
+     */
+    public static void clear() {
+        int[] stats = STATS.get();
+        int hits = stats[0];
+        int misses = stats[1];
+        int uniqueUsers = CACHE.get().size();
+        if (hits + misses > 0) {
+            logger.info("UserResolutionCache request summary: {} unique user(s) resolved, {} cache hit(s), {} cache miss(es)",
+                    uniqueUsers, hits, misses);
+        }
+        CACHE.remove();
+        STATS.remove();
+    }
+
+    private static String cacheKey(String username, String siteKey) {
+        return (siteKey != null ? siteKey : "") + "\0" + username;
+    }
+}

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserResolutionCache.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/UserResolutionCache.java
@@ -15,6 +15,8 @@
  */
 package org.jahia.modules.graphql.provider.dxm.user;
 
+import org.jahia.services.content.decorator.JCRUserNode;
+import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,21 +58,14 @@ public final class UserResolutionCache {
     }
 
     /**
-     * Returns the cached user for {@code (username, siteKey)}, or {@code null} if not present.
-     * A return value of {@link Optional#empty()} means the user was looked up and does not exist.
+     * Returns whether the cache contains an entry for {@code (username, siteKey)}.
      *
      * @param username the username to look up (never {@code null})
      * @param siteKey  the site key, or {@code null} for global users
-     * @return the cached {@link Optional} entry, or {@code null} if not in cache
+     * @return {@code true} if a cache entry exists (even for a non-existent user)
      */
-    public static Optional<GqlUser> getIfPresent(String username, String siteKey) {
-        Optional<GqlUser> cached = CACHE.get().get(cacheKey(username, siteKey));
-        if (cached != null) {
-            STATS.get()[0]++;
-        } else {
-            STATS.get()[1]++;
-        }
-        return cached;
+    private static boolean isCached(String username, String siteKey) {
+        return CACHE.get().containsKey(cacheKey(username, siteKey));
     }
 
     /**
@@ -101,6 +96,30 @@ public final class UserResolutionCache {
         }
         CACHE.remove();
         STATS.remove();
+    }
+
+    /**
+     * Resolves a {@link GqlUser} for the given username, using the request-scoped cache to
+     * avoid repeated {@code lookupUser} calls within the same GraphQL execution.
+     *
+     * @param username           the username to resolve; {@code null} or blank returns {@code null}
+     * @param siteKey            the site key for site-scoped lookup, or {@code null} for global users
+     * @param userManagerService the OSGi user manager service
+     * @return the resolved {@link GqlUser}, or {@code null} if the user does not exist, or if the user manager service is {@code null}
+     */
+    public static GqlUser resolve(String username, String siteKey, JahiaUserManagerService userManagerService) {
+        if (username == null || username.isEmpty() || userManagerService == null) {
+            return null;
+        }
+        if (isCached(username, siteKey)) {
+            STATS.get()[0]++;
+            return CACHE.get().get(cacheKey(username, siteKey)).orElse(null);
+        }
+        STATS.get()[1]++;
+        JCRUserNode userNode = userManagerService.lookupUser(username, siteKey);
+        GqlUser result = userNode != null ? new GqlUser(userNode.getJahiaUser()) : null;
+        put(username, siteKey, result);
+        return result;
     }
 
     private static String cacheKey(String username, String siteKey) {


### PR DESCRIPTION
### Description

Add JCR Node extension API that maps user-related properties to static endpoints (e.g. `jcr:createdBy` > `createdByUser`, `jcr:lastModifiedBy` > `lastModifiedByUser`, etc) that retrieves user metadata properties (`GqlUser`) associated to the username.

We also add user resolution cache to avoid duplicate lookups for bulk requests.

TODO 

- Add tests

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
