### PR TITLE
fix: Filter out jmix:hiddenNode types when getting children

### DIFF
--- a/.chachalog/WRLScfb6.md
+++ b/.chachalog/WRLScfb6.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+graphql-core: minor
+---
+
+Filter out jmix:hiddenNode types when getting children/descendants (#609)

--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -395,6 +395,13 @@
                     <outputName>java-bom.cdx</outputName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <testNGArtifactName>none:none</testNGArtifactName>
+                </configuration>
+            </plugin>
         </plugins>
 
     </build>

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
@@ -74,7 +74,7 @@ import static org.jahia.modules.graphql.provider.dxm.node.NodeHelper.getTypesPre
 @GraphQLDescription("GraphQL representation of a generic JCR node")
 public class GqlJcrNodeImpl implements GqlJcrNode {
 
-    public static final List<String> DEFAULT_EXCLUDED_CHILDREN = Arrays.asList("jnt:translation");
+    public static final List<String> DEFAULT_EXCLUDED_CHILDREN = Arrays.asList("jnt:translation", "jmix:hiddenNode");
     public static final Predicate<JCRNodeWrapper> DEFAULT_CHILDREN_PREDICATE = getTypesPredicate(new NodeTypesInput(MulticriteriaEvaluation.NONE, DEFAULT_EXCLUDED_CHILDREN));
     private static final Logger log = LoggerFactory.getLogger(GqlJcrNodeImpl.class);
 

--- a/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/utils/ZipUtilsTest.java
+++ b/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/utils/ZipUtilsTest.java
@@ -17,7 +17,7 @@ package org.jahia.modules.graphql.utils;
 
 import org.jahia.modules.graphql.provider.dxm.util.ZipUtils;
 import org.junit.Test;
-import org.testng.Assert;
+import org.junit.Assert;
 
 import java.io.IOException;
 
@@ -25,11 +25,11 @@ public class ZipUtilsTest {
 
     @Test
     public void testMimeType() throws IOException {
-        Assert.assertEquals(ZipUtils.getMimeType("test.css", null), "text/css");
-        Assert.assertEquals(ZipUtils.getMimeType("test", getClass().getResourceAsStream("/mime-samples/text")), "text/plain");
-        Assert.assertEquals(ZipUtils.getMimeType("test", getClass().getResourceAsStream("/mime-samples/text-csv")), "text/plain");
-        Assert.assertEquals(ZipUtils.getMimeType("excel.xlsx", null), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        Assert.assertEquals(ZipUtils.getMimeType("excel-xlsx", getClass().getResourceAsStream("/mime-samples/excel.xlsx")), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        Assert.assertEquals(ZipUtils.getMimeType("excel-xlsx", getClass().getResourceAsStream("/mime-samples/excel")), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        Assert.assertEquals("text/css", ZipUtils.getMimeType("test.css", null));
+        Assert.assertEquals("text/plain", ZipUtils.getMimeType("test", getClass().getResourceAsStream("/mime-samples/text")));
+        Assert.assertEquals("text/plain", ZipUtils.getMimeType("test", getClass().getResourceAsStream("/mime-samples/text-csv")));
+        Assert.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ZipUtils.getMimeType("excel.xlsx", null));
+        Assert.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ZipUtils.getMimeType("excel-xlsx", getClass().getResourceAsStream("/mime-samples/excel.xlsx")));
+        Assert.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ZipUtils.getMimeType("excel-xlsx", getClass().getResourceAsStream("/mime-samples/excel")));
     }
 }


### PR DESCRIPTION
### Description
Filter out jmix:hiddenNode types when getting children so that they do not show up in UI/Managers and stay actually hidden.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
