### PR TITLE
fix: Add logic for default view depending on context config

### DIFF
--- a/.chachalog/WsRT_7Fr.md
+++ b/.chachalog/WsRT_7Fr.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+graphql-core: minor
+---
+
+`renderedContent` now falls back to the default view (instead of cm) when rendering in page context with no view specified. (#617)

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/render/RenderNodeExtensions.java
@@ -154,7 +154,12 @@ public class RenderNodeExtensions {
 
             if (view == null) {
                 String definedView = node.hasProperty("j:view") ? node.getPropertyAsString("j:view") : null;
-                view = definedView != null && !definedView.isEmpty() ? definedView : "cm";
+                if (definedView != null && !definedView.isEmpty()) {
+                    view = definedView;
+                } else {
+                    // Use 'default' view for page rendering if no view is defined; otherwise we use cm template
+                    view = Resource.CONFIGURATION_PAGE.equals(contextConfiguration) ? "default" : "cm";
+                }
             }
 
             Resource r = new Resource(node, templateType, view, contextConfiguration);

--- a/tests/cypress/e2e/api/graphqlRenderTest.cy.ts
+++ b/tests/cypress/e2e/api/graphqlRenderTest.cy.ts
@@ -452,6 +452,104 @@ describe('Test graphql rendering', () => {
         deleteNode('/sites/' + sitename + '/home/text1');
     });
 
+    it('uses default view when contextConfiguration is page and no view is set', () => {
+        addNode({
+            parentPathOrId: `/sites/${sitename}/home`,
+            name: 'pageContextDefault',
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Page Context Default', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ]
+        });
+
+        cy.apollo({
+            query: gql`query {
+                jcr {
+                    nodeByPath(path: "/sites/${sitename}/home/pageContextDefault") {
+                        renderedContent(contextConfiguration: "page") {
+                            output
+                        }
+                    }
+                }
+            }`
+        }).should(result => {
+            const output = result?.data?.jcr?.nodeByPath?.renderedContent.output;
+            // With contextConfiguration "page" and no j:view, view resolves to "default"
+            // which renders the actual page template — not the "cm" fallback
+            expect(output).to.not.be.empty;
+            expect(output).to.not.contain('No rendering set for node');
+        });
+
+        deleteNode(`/sites/${sitename}/home/pageContextDefault`);
+    });
+
+    it('falls back to cm view when contextConfiguration is not page and no view is set', () => {
+        addNode({
+            parentPathOrId: `/sites/${sitename}/home`,
+            name: 'newsCmFallback',
+            primaryNodeType: 'gqltest:news',
+            properties: [
+                {name: 'title', language: 'en', value: 'CM Fallback News'},
+                {name: 'author', value: 'Test Author'}
+            ]
+        });
+
+        cy.apollo({
+            query: gql`query {
+                jcr {
+                    nodeByPath(path: "/sites/${sitename}/home/newsCmFallback") {
+                        renderedContent(contextConfiguration: "module") {
+                            output
+                        }
+                    }
+                }
+            }`
+        }).should(result => {
+            const output = result?.data?.jcr?.nodeByPath?.renderedContent.output;
+            // With contextConfiguration "module" and no j:view, view resolves to "cm"
+            // which renders news.cm.jsp — the distinctive cm view for gqltest:news
+            expect(output).to.contain('gqltest-news-cm');
+            expect(output).to.contain('newsCmFallback');
+        });
+
+        deleteNode(`/sites/${sitename}/home/newsCmFallback`);
+    });
+
+    it('j:view property takes priority over cm fallback when no view is set', () => {
+        addNode({
+            parentPathOrId: `/sites/${sitename}/home`,
+            name: 'jviewPriorityNode',
+            primaryNodeType: 'jnt:bigText',
+            properties: [
+                {name: 'text', language: 'en', value: 'priority test'},
+                {name: 'j:view', language: 'en', value: 'link'}
+            ],
+            mixins: ['jmix:renderable']
+        });
+
+        cy.apollo({
+            query: gql`query {
+                jcr {
+                    nodeByPath(path: "/sites/${sitename}/home/jviewPriorityNode") {
+                        renderedContent(contextConfiguration: "module") {
+                            output
+                        }
+                    }
+                }
+            }`
+        }).should(result => {
+            const output = result?.data?.jcr?.nodeByPath?.renderedContent.output;
+            // 'j:view' "link" must be used instead of the "cm" fallback;
+            // the link view renders an anchor tag for this node
+            expect(output).to.contain(
+                `<a target="" href="/cms/render/default/en/sites/${sitename}/home/jviewPriorityNode.html">jviewPriorityNode</a>`
+            );
+        });
+
+        deleteNode(`/sites/${sitename}/home/jviewPriorityNode`);
+    });
+
     it('Check renderedContent works correctly for multiple nodes in single query', () => {
         // Create two text nodes
         addTestNode({

--- a/tests/jahia-module/misc-test-module/src/main/resources/gqltest_news/html/news.cm.jsp
+++ b/tests/jahia-module/misc-test-module/src/main/resources/gqltest_news/html/news.cm.jsp
@@ -1,0 +1,3 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<div class="gqltest-news-cm">${currentNode.name}</div>


### PR DESCRIPTION
### Description

Use default view template if there is no defined view for a page context configuration. 'cm' should only be rendered for module contexts.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
