### PR TITLE
fix: undeprecate User.name

### DIFF
--- a/.chachalog/N4etWGxe.md
+++ b/.chachalog/N4etWGxe.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+graphql-core: patch
+---
+
+Undeprecated `User.name` to address a GraphQL specification violation. (#633)

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUser.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUser.java
@@ -55,8 +55,7 @@ public class GqlUser implements GqlPrincipal {
 
     @GraphQLField
     @GraphQLNonNull
-    @GraphQLDeprecate
-    @GraphQLDescription("User name")
+    @GraphQLDescription("Username (same as .username)")
     @Override
     public String getName() {
         return user.getName();
@@ -64,7 +63,7 @@ public class GqlUser implements GqlPrincipal {
 
     @GraphQLField
     @GraphQLNonNull
-    @GraphQLDescription("Username of the user")
+    @GraphQLDescription("Username (same as .name)")
     public String getUsername() {
         return user.getName();
     }


### PR DESCRIPTION
Address a violation of the gql spec: https://github.com/graphql/graphql-spec/blame/89d93ebbe05db06787646d76a696ead8de117b2b/spec/Section%203%20--%20Type%20System.md#L970

User implements Principal, User.name is deprecated but Principal.name is not, this is forbidden

Undeprecate User.name

