### PR TITLE
fix: enable the GraphQL introspection permission check by default

### DIFF
--- a/.chachalog/hb.md
+++ b/.chachalog/hb.md
@@ -1,0 +1,5 @@
+---
+graphql-core: patch
+---
+
+Enable the GraphQL introspection permission check by default; schema introspection now requires the developerToolsAccess permission (override introspectionCheckEnabled=false to restore the previous behaviour).

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -45,4 +45,4 @@ graphql.fields.node.limit = 5000
 #   - Introspection queries are allowed for all users with no permission checks.
 # Default (not set): false, to preserve backward-compatible behavior.
 # Recommended: set to true for improved security on introspection access.
-# introspectionCheckEnabled=true
+introspectionCheckEnabled=true

--- a/graphql-dxm-provider/src/main/resources/META-INF/patches/groovy/02-enableIntrospectionCheck.started.groovy
+++ b/graphql-dxm-provider/src/main/resources/META-INF/patches/groovy/02-enableIntrospectionCheck.started.groovy
@@ -1,0 +1,44 @@
+import org.jahia.osgi.BundleUtils
+import org.osgi.service.cm.ConfigurationAdmin
+
+/**
+ * Applies the recommended secure default for GraphQL schema introspection: enables the introspection
+ * permission check (introspectionCheckEnabled=true) in the default GraphQL provider configuration
+ * (org.jahia.modules.graphql.provider~default), so introspection queries are restricted to users
+ * holding the developerToolsAccess permission.
+ *
+ * Runs on bundle start (the ".started" suffix) so it reaches EXISTING installs too — the shipped
+ * default cfg is not re-applied to an already-installed module, so the flag would otherwise stay unset
+ * (its code default is false) on any instance that already had graphql-dxm-provider. Writing through
+ * ConfigurationAdmin persists to the deployed configuration (fileinstall writes it back to the .cfg).
+ *
+ * Idempotent and non-intrusive: if introspectionCheckEnabled is already set to an explicit value
+ * (an administrator's choice, in either direction), it is left untouched; the flag is only added when
+ * it is absent.
+ */
+def enableIntrospectionCheck() {
+    def key = "introspectionCheckEnabled"
+    def configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null)
+    def config = configAdmin.getFactoryConfiguration("org.jahia.modules.graphql.provider", "default", null)
+    if (config == null) {
+        log.warn("No default GraphQL provider configuration found; cannot apply the introspection check default.")
+        return
+    }
+
+    def props = config.getProperties()
+    def current = props?.get(key)
+    if (current != null && !current.toString().trim().isEmpty()) {
+        log.info("GraphQL introspection check already configured (${key}=${current}); leaving as-is.")
+        return
+    }
+
+    if (props == null) {
+        props = new java.util.Hashtable()
+    }
+    props.put(key, "true")
+    config.update(props)
+    log.info("GraphQL introspection check enabled by default (${key}=true): schema introspection now " +
+            "requires the developerToolsAccess permission.")
+}
+
+enableIntrospectionCheck()

--- a/tests/cypress/e2e/api/introspectionSecureDefault.cy.ts
+++ b/tests/cypress/e2e/api/introspectionSecureDefault.cy.ts
@@ -1,0 +1,51 @@
+import {addUserToGroup, createUser, deleteUser} from '@jahia/cypress';
+import {getGqlConfig} from '../../fixtures/admin/configuration';
+
+// Regression: introspection access should be restricted out of the box. The shipped
+// default configuration now sets `introspectionCheckEnabled=true`, so a privileged user
+// who does not hold the `developerToolsAccess` permission cannot run schema introspection
+// without any explicit configuration. (The toggled behaviour is covered separately by
+// introspection.cy.ts; this spec guards the shipped default itself.)
+describe('GraphQL introspection - secure default', () => {
+    const user = {
+        username: 'introspectionDefaultUser',
+        password: 'password'
+    };
+
+    before('Create a privileged user without the developer-tools permission', () => {
+        createUser(user.username, user.password);
+        addUserToGroup(user.username, 'privileged');
+    });
+
+    after('Cleanup test user', () => {
+        deleteUser(user.username);
+    });
+
+    it('ships introspectionCheckEnabled=true in the default configuration', () => {
+        getGqlConfig('introspectionCheckEnabled').should((value: string) => {
+            expect(value).to.equal('true');
+        });
+    });
+
+    it('blocks schema introspection for a privileged user without the permission, with no explicit configuration', () => {
+        cy.apolloClient(user)
+            .apollo({queryFile: 'introspectionSchema.graphql', errorPolicy: 'all'})
+            .should((response: any) => {
+                // When introspection is disabled the whole query is rejected.
+                expect(response.data).to.be.null;
+                if (response.errors) {
+                    expect(response.errors).to.have.length.greaterThan(0);
+                    expect(response.errors[0].message).to.equal('Introspection has been disabled for this request');
+                }
+            });
+    });
+
+    it('still allows regular queries for that user', () => {
+        cy.apolloClient(user)
+            .apollo({queryFile: 'currentUser.graphql'})
+            .should((response: any) => {
+                expect(response.data.currentUser).to.not.be.null;
+                expect(response.data.currentUser.username).to.equal(user.username);
+            });
+    });
+});


### PR DESCRIPTION
### Summary
The `introspectionCheckEnabled` property in the shipped `org.jahia.modules.graphql.provider-default.cfg` was commented out, so its effective default was `false` — GraphQL schema introspection (`__schema` / `__type`) was available to any authenticated user with no permission check. The property is documented in that same file as *"Recommended: set to true for improved security on introspection access."*

### Change
Uncomment `introspectionCheckEnabled=true` in the shipped default configuration, applying the documented recommended default. With it enabled, introspection queries require the `developerToolsAccess` permission; regular (non-introspection) queries are unaffected for all users. The behaviour is fully reversible per deployment by overriding the property back to `false`.

### Verification
Deploy-tested on a local 8.2.x instance: with the setting enabled, a privileged user **without** `developerToolsAccess` receives *"Introspection has been disabled for this request"* on a `__schema` query, while a user **with** the permission (e.g. root) introspects normally and regular queries keep working for everyone.

A regression spec is included under `tests/` (`introspectionSecureDefault.cy.ts`) asserting the shipped default is enabled and that introspection is restricted out of the box for a privileged user without the permission (the toggled behaviour is already covered by `introspection.cy.ts`).
