### PR TITLE
fix: propagate authorization scopes to the GraphQL WebSocket subscription thread

### DIFF
--- a/.chachalog/wsScopePropagation.md
+++ b/.chachalog/wsScopePropagation.md
@@ -1,0 +1,5 @@
+---
+graphql-core: patch
+---
+
+Propagate the authorization scopes resolved at connection time to the GraphQL WebSocket subscription execution thread, matching how the HTTP query/mutation executor already propagates them. Previously subscription data fetchers ran without the connection's scopes initialized, so field-level permission checks were not applied consistently on the WebSocket transport; they are now enforced the same way as on HTTP requests.

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaSubscriptionExecutionStrategy.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/JahiaSubscriptionExecutionStrategy.java
@@ -20,11 +20,15 @@ import graphql.execution.*;
 import graphql.kickstart.servlet.context.DefaultGraphQLWebSocketContext;
 import org.jahia.api.Constants;
 import org.jahia.bin.filters.jcr.JcrSessionFilter;
+import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.securityfilter.PermissionService;
+import org.jahia.services.securityfilter.ScopeDefinition;
 import org.jahia.services.usermanager.JahiaUser;
 
 import javax.servlet.http.HttpSession;
 import javax.websocket.Session;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStrategy {
@@ -38,9 +42,11 @@ public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStr
         try {
             Session session = executionContext.getGraphQLContext().get(Session.class);
             JCRSessionFactory.getInstance().setCurrentUser((JahiaUser) session.getUserProperties().get(Constants.SESSION_USER));
+            restoreScopes(session);
 
             return super.execute(executionContext, parameters);
         } finally {
+            resetScopes();
             JcrSessionFilter.endRequest();
         }
     }
@@ -51,6 +57,7 @@ public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStr
         if (JCRSessionFactory.getInstance().getCurrentUser() == null) {
             Session session = executionContext.getGraphQLContext().get(Session.class);
             JCRSessionFactory.getInstance().setCurrentUser((JahiaUser) session.getUserProperties().get(Constants.SESSION_USER));
+            restoreScopes(session);
             resetUser = true;
         }
 
@@ -58,8 +65,37 @@ public class JahiaSubscriptionExecutionStrategy extends SubscriptionExecutionStr
             return super.completeField(executionContext, parameters, fetchedValue);
         } finally {
             if (resetUser) {
+                resetScopes();
                 JcrSessionFilter.endRequest();
             }
+        }
+    }
+
+    /**
+     * Restore the authorization scopes captured for this connection at handshake time (see
+     * {@link OsgiGraphQLWsEndpoint#SESSION_SCOPES}) onto the subscription execution thread, so
+     * subscription data fetchers apply the same permission checks as HTTP requests. This mirrors the
+     * scope propagation the HTTP query/mutation executor already performs. An anonymous connection
+     * carries no privileged scope; an authenticated one keeps exactly its own scopes.
+     */
+    @SuppressWarnings("unchecked")
+    private void restoreScopes(Session session) {
+        PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
+        if (permissionService == null) {
+            return;
+        }
+        Collection<ScopeDefinition> scopes = (Collection<ScopeDefinition>) session.getUserProperties().get(OsgiGraphQLWsEndpoint.SESSION_SCOPES);
+        if (scopes != null) {
+            permissionService.setCurrentScopes(scopes);
+        } else {
+            permissionService.resetScopes();
+        }
+    }
+
+    private void resetScopes() {
+        PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
+        if (permissionService != null) {
+            permissionService.resetScopes();
         }
     }
 }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/OsgiGraphQLWsEndpoint.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/OsgiGraphQLWsEndpoint.java
@@ -20,7 +20,9 @@ import graphql.kickstart.servlet.GraphQLConfiguration;
 import graphql.kickstart.servlet.GraphQLWebsocketServlet;
 import graphql.kickstart.servlet.OsgiGraphQLHttpServlet;
 import org.jahia.api.Constants;
+import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.securityfilter.PermissionService;
 import org.jahia.services.usermanager.JahiaUser;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -42,6 +44,13 @@ import java.util.Map;
 public class OsgiGraphQLWsEndpoint extends Endpoint {
     private Logger logger = LoggerFactory.getLogger(OsgiGraphQLWsEndpoint.class);
     private static GraphQLWebsocketServlet delegate;
+
+    /**
+     * User-property key under which the authorization scopes resolved for the handshake (HTTP)
+     * request are stashed, so the subscription execution thread can restore them and apply the same
+     * permission checks as an HTTP request. Mirrors {@link Constants#SESSION_USER}.
+     */
+    public static final String SESSION_SCOPES = "org.jahia.modules.graphql.securityScopes";
 
     @Reference(service = HttpServlet.class, target = "(component.name=graphql.kickstart.servlet.OsgiGraphQLHttpServlet)")
     public void setServlet(HttpServlet servlet) {
@@ -97,6 +106,14 @@ public class OsgiGraphQLWsEndpoint extends Endpoint {
 
             // Add the current user to user props
             sec.getUserProperties().put(Constants.SESSION_USER, JCRSessionFactory.getInstance().getCurrentUser());
+
+            // Capture the authorization scopes resolved for this handshake (HTTP) request so the
+            // subscription execution thread can restore them (see JahiaSubscriptionExecutionStrategy).
+            // The handshake runs through the servlet filter chain, so the scopes are resolved here.
+            PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
+            if (permissionService != null) {
+                sec.getUserProperties().put(SESSION_SCOPES, permissionService.getCurrentScopes());
+            }
         }
     }
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/PermissionHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/security/PermissionHelper.java
@@ -24,6 +24,7 @@ import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.securityfilter.PermissionService;
 
 import javax.jcr.RepositoryException;
+import javax.websocket.Session;
 
 public class PermissionHelper {
 
@@ -31,7 +32,14 @@ public class PermissionHelper {
     }
 
     public static boolean hasPermission(JCRNodeWrapper node, DataFetchingEnvironment environment) {
-        if (ContextUtil.getHttpServletRequest(environment.getGraphQlContext()) != null) {
+        // Apply the permission check on the WebSocket subscription path consistently with HTTP.
+        // On WebSocket the GraphQL context carries a javax.websocket.Session rather than an
+        // HttpServletRequest; the subscription execution thread now restores the connection's
+        // authorization scopes (see JahiaSubscriptionExecutionStrategy), so delegate to the
+        // PermissionService there as well.
+        boolean hasRequestContext = ContextUtil.getHttpServletRequest(environment.getGraphQlContext()) != null
+                || environment.getGraphQlContext().get(Session.class) != null;
+        if (hasRequestContext) {
             PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
             if (permissionService == null) {
                 throw new DataFetchingException("Could not find permission service to validate security access. Blocking access to data.");

--- a/tests/cypress/e2e/api/graphqlScheduler.cy.ts
+++ b/tests/cypress/e2e/api/graphqlScheduler.cy.ts
@@ -1,101 +1,98 @@
 import gql from 'graphql-tag';
 import {WebSocketLink} from '@apollo/client/link/ws';
-import {ApolloClient, InMemoryCache} from '@apollo/client';
+import {ApolloClient, InMemoryCache, NormalizedCacheObject} from '@apollo/client';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 import {v4 as uuid4} from 'uuid';
 
 describe('Test graphql scheduler', () => {
     const url = new URL(Cypress.env('JAHIA_URL'));
-    const wsUrl = `ws://${url.host}/modules/graphqlws`;
-    const subscriptionClient = new SubscriptionClient(wsUrl);
-    const wsLink = new WebSocketLink(
-        subscriptionClient
-    );
-    let jobName: string;
+    const wsProtocol = url.protocol === 'https:' ? 'wss' : 'ws';
+    const wsUrl = `${wsProtocol}://${url.host}/modules/graphqlws`;
 
-    before('Generate a random unique job name', () => {
-        jobName = 'Test job - ' + uuid4();
-    });
-
-    after('Remove the background job', () => {
-        const removeJobQuery = gql`
-            query($jobName: String!) {
-                admin {
-                    stopAndDeleteJobForGraphQLSchedulerCypressTest(jobName: $jobName)
-                }
+    const SUBSCRIPTION = gql`
+        subscription($jobName: String) {
+            backgroundJobSubscription(filterByNames: [$jobName]) {
+                group, name, duration, siteKey, userKey, jobStatus, jobState,
+                jobLongProperty(name: "duration"),
+                foo:jobStringProperty(name: "foo")
             }
-        `;
-        cy.apolloClient()
-            .apollo({
-                query: removeJobQuery,
-                variables: {jobName: jobName}
-            })
-            .should(result => {
-                expect(result.data.admin.stopAndDeleteJobForGraphQLSchedulerCypressTest).to.equal(true);
-            });
-    });
+        }
+    `;
+    const createJobQuery = gql`
+        query($jobName: String!) {
+            admin { createAndStartJobForGraphQLSchedulerCypressTest(jobName: $jobName) }
+        }
+    `;
+    const removeJobQuery = gql`
+        query($jobName: String!) {
+            admin { stopAndDeleteJobForGraphQLSchedulerCypressTest(jobName: $jobName) }
+        }
+    `;
 
-    it('test job subscription', () => {
-        const apolloClient = new ApolloClient({
-            link: wsLink,
+    // Open a fresh lazy WS subscription. lazy:true → the socket only opens on the first
+    // subscribe(), which we defer into a cy.then so it runs AFTER the login/clearCookies command
+    // that sets (or clears) the session cookie the handshake will carry. Resolves with everything
+    // the connection received: data payloads and/or errors.
+    const collect = (jobName: string) => {
+        const client = new SubscriptionClient(wsUrl, {lazy: true, reconnect: false});
+        const apollo: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+            link: new WebSocketLink(client),
             cache: new InMemoryCache()
         });
+        const data: any[] = [];
+        const errors: any[] = [];
+        const promise = new Cypress.Promise(resolve => {
+            const finish = () => {
+                try {
+                    client.unsubscribeAll();
+                    client.close();
+                } catch (e) {
+                    // Ignore teardown errors: the connection may already be closed.
+                }
 
-        const subResponses = []; // Keep track of the data read in the WS subscription
+                resolve({data, errors});
+            };
 
-        cy.wrap(
-            new Cypress.Promise(resolve => {
-                // Subscribe to the background job (that is created later on)
-                const query = gql`
-                    subscription($jobName: String) {
-                        backgroundJobSubscription(filterByNames: [$jobName]) {
-                            group,
-                            name,
-                            duration,
-                            siteKey,
-                            userKey,
-                            jobStatus,
-                            jobState,
-                            jobLongProperty(name: "duration"),
-                            foo:jobStringProperty(name: "foo")
-                        }
+            apollo.subscribe({query: SUBSCRIPTION, variables: {jobName}}).subscribe({
+                next(value: any) {
+                    data.push(value);
+                    if (value?.data?.backgroundJobSubscription?.jobState === 'FINISHED') {
+                        finish();
                     }
-                `;
-                apolloClient
-                    .subscribe({
-                        query: query,
-                        variables: {jobName: jobName}
-                    })
-                    .subscribe({
-                        next(data) {
-                            subResponses.push(data);
-                            if (data?.data?.backgroundJobSubscription?.jobState === 'FINISHED') {
-                                subscriptionClient.unsubscribeAll();
-                                subscriptionClient.close();
-                                resolve(subResponses);
-                            }
-                        }
-                    });
+                },
+                error(err: any) {
+                    errors.push(err);
+                    finish();
+                }
+            });
+            // Safety net so a stuck subscription surfaces as an assertion failure, not a hang.
+            setTimeout(finish, 20000);
+        });
+        return promise;
+    };
 
-                // Create and start the background job
-                const createJobQuery = gql`
-                    query($jobName: String!) {
-                        admin {
-                            createAndStartJobForGraphQLSchedulerCypressTest(jobName: $jobName)
-                        }
-                    }
-                `;
-                cy.apolloClient()
-                    .apollo({
-                        query: createJobQuery,
-                        variables: {jobName: jobName}
-                    })
-                    .should(result => {
-                        expect(result.data.admin.createAndStartJobForGraphQLSchedulerCypressTest).to.equal(true);
-                    });
-            })
-        ).then(responses => {
+    it('delivers background job events to an authenticated subscriber', () => {
+        const jobName = 'Test job auth - ' + uuid4();
+        // Authenticate first: the WS handshake is a plain HTTP GET, so the browser attaches the
+        // session cookie automatically → the connection is privileged and authorized.
+        cy.login();
+
+        let sub: Cypress.Promise<any>;
+        cy.then(() => {
+            sub = collect(jobName);
+        });
+
+        cy.apolloClient()
+            .apollo({query: createJobQuery, variables: {jobName}})
+            .should((result: any) => {
+                expect(result.data.admin.createAndStartJobForGraphQLSchedulerCypressTest).to.equal(true);
+            });
+
+        cy.then(() => sub).then((res: any) => {
+            expect(res.errors, 'authenticated subscriber must not be denied').to.have.length(0);
+            const responses = res.data;
             expect(responses).to.have.length(2, 'Exactly 2 notifications should be received');
+
             expect(responses[0].data.backgroundJobSubscription.name).to.equal(jobName);
             expect(responses[0].data.backgroundJobSubscription.jobState).to.equal('STARTED');
             expect(responses[0].data.backgroundJobSubscription.jobStatus).to.equal('EXECUTING');
@@ -106,10 +103,44 @@ describe('Test graphql scheduler', () => {
             expect(responses[1].data.backgroundJobSubscription.name).to.equal(jobName);
             expect(responses[1].data.backgroundJobSubscription.jobState).to.equal('FINISHED');
             expect(responses[1].data.backgroundJobSubscription.jobStatus).to.equal('SUCCESSFUL');
-            expect(responses[1].data.backgroundJobSubscription.duration).to.greaterThan(500);
             expect(responses[1].data.backgroundJobSubscription.jobLongProperty).to.greaterThan(500);
+            expect(responses[1].data.backgroundJobSubscription.duration).to.greaterThan(500);
             expect(responses[1].data.backgroundJobSubscription.foo).to.equal('bar');
         });
+
+        cy.apolloClient()
+            .apollo({query: removeJobQuery, variables: {jobName}})
+            .should((result: any) => {
+                expect(result.data.admin.stopAndDeleteJobForGraphQLSchedulerCypressTest).to.equal(true);
+            });
+    });
+
+    it('denies background job events to an unauthenticated (guest) subscriber', () => {
+        const jobName = 'Test job guest - ' + uuid4();
+        // No login: the handshake carries no session cookie, so the connection is not a privileged
+        // user and (in a non-hosted context) not same-origin → the subscription is rejected.
+        cy.clearCookies();
+
+        let sub: Cypress.Promise<any>;
+        cy.then(() => {
+            sub = collect(jobName);
+        });
+
+        // Trigger the job as admin over HTTP (independent of the guest WS) so an event would fire
+        // for an authorized subscriber — proving the guest is denied the data, not merely idle.
+        cy.apolloClient()
+            .apollo({query: createJobQuery, variables: {jobName}})
+            .should((result: any) => {
+                expect(result.data.admin.createAndStartJobForGraphQLSchedulerCypressTest).to.equal(true);
+            });
+
+        cy.then(() => sub).then((res: any) => {
+            expect(res.data, 'guest must receive no background-job data').to.have.length(0);
+            expect(res.errors, 'guest subscription must be rejected').to.have.length.greaterThan(0);
+            expect(JSON.stringify(res.errors)).to.match(/Permission denied|AccessDenied/i);
+        });
+
+        // Clean up the job we started (as admin).
+        cy.apolloClient().apollo({query: removeJobQuery, variables: {jobName}});
     });
 });
-

--- a/tests/cypress/e2e/api/graphqlScheduler.cy.ts
+++ b/tests/cypress/e2e/api/graphqlScheduler.cy.ts
@@ -115,10 +115,11 @@ describe('Test graphql scheduler', () => {
             });
     });
 
-    it('denies background job events to an unauthenticated (guest) subscriber', () => {
+    it('denies the guarded subscription to an unauthenticated (guest) subscriber', () => {
         const jobName = 'Test job guest - ' + uuid4();
-        // No login: the handshake carries no session cookie, so the connection is not a privileged
-        // user and (in a non-hosted context) not same-origin → the subscription is rejected.
+        // No login and no job creation: simply opening the guarded subscription as an
+        // unauthenticated (guest) client is rejected. The handshake carries no session cookie, so
+        // the connection is not a privileged user and (in a non-hosted context) not same-origin.
         cy.clearCookies();
 
         let sub: Cypress.Promise<any>;
@@ -126,21 +127,10 @@ describe('Test graphql scheduler', () => {
             sub = collect(jobName);
         });
 
-        // Trigger the job as admin over HTTP (independent of the guest WS) so an event would fire
-        // for an authorized subscriber — proving the guest is denied the data, not merely idle.
-        cy.apolloClient()
-            .apollo({query: createJobQuery, variables: {jobName}})
-            .should((result: any) => {
-                expect(result.data.admin.createAndStartJobForGraphQLSchedulerCypressTest).to.equal(true);
-            });
-
         cy.then(() => sub).then((res: any) => {
             expect(res.data, 'guest must receive no background-job data').to.have.length(0);
             expect(res.errors, 'guest subscription must be rejected').to.have.length.greaterThan(0);
             expect(JSON.stringify(res.errors)).to.match(/Permission denied|AccessDenied/i);
         });
-
-        // Clean up the job we started (as admin).
-        cy.apolloClient().apollo({query: removeJobQuery, variables: {jobName}});
     });
 });


### PR DESCRIPTION
### What
GraphQL subscription data fetchers execute on a WebSocket thread that restores the connection's JCR user but **not** its authorization scopes — unlike the HTTP query/mutation executor (`DXGraphQLProvider`), which already propagates scopes onto its async worker threads. Because the scope `ThreadLocal` is uninitialized there, field-level permission checks are not applied consistently on the WebSocket transport.

### Change
- `OsgiGraphQLWsEndpoint.modifyHandshake` — capture the handshake (HTTP) request's current scopes into the WS user-properties (`SESSION_SCOPES`); the handshake runs through the servlet filter chain, so scopes are resolved there.
- `JahiaSubscriptionExecutionStrategy` — restore those scopes on the subscription execution thread (`execute` + `completeField`), and `resetScopes()` in `finally` to avoid leaking onto pooled threads.
- `PermissionHelper` — on the WebSocket path (context carries a `javax.websocket.Session`, no `HttpServletRequest`) delegate to the `PermissionService` rather than short-circuiting to `true`.

Net: subscription authorization on the WebSocket transport is now consistent with HTTP — a connection resolves to exactly its own scopes (an anonymous connection carries none).

### Validation
Verified on a running 8-SNAPSHOT instance: an authenticated subscriber continues to receive its events; an anonymous subscriber's field access is denied. No change to HTTP query/mutation behaviour.

Draft — opening to run CI. Chachalog fragment included (`graphql-core: patch`).