### PR TITLE
docs: describe admin GraphQL enums reachable under JahiaAdminQuery

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrPropertyType.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrPropertyType.java
@@ -15,6 +15,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.node;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLName;
 
 import javax.jcr.PropertyType;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @GraphQLName("JCRPropertyType")
+@GraphQLDescription("Type of a JCR property (as defined by javax.jcr.PropertyType)")
 public enum GqlJcrPropertyType {
     BOOLEAN(PropertyType.BOOLEAN),
     DATE(PropertyType.DATE),

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/GroupingHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/GroupingHelper.java
@@ -33,6 +33,7 @@ public class GroupingHelper {
 
     private static final String UNGROUPED_LIST = "theRest";
 
+    @GraphQLDescription("How grouped items are positioned relative to the ungrouped ones")
     public enum GroupingType {
 
         @GraphQLDescription("Put grouped items at the end in the order groups appear in the 'groups' list")

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/MulticriteriaEvaluation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/MulticriteriaEvaluation.java
@@ -20,6 +20,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 /**
  * A way to evaluate a criteria consisting of multiple sub-criteria.
  */
+@GraphQLDescription("A way to evaluate a criteria consisting of multiple sub-criteria")
 public enum MulticriteriaEvaluation {
 
     /**

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/SorterHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/predicate/SorterHelper.java
@@ -28,6 +28,7 @@ import java.util.Map;
  */
 public class SorterHelper {
 
+    @GraphQLDescription("Sort order direction")
     public enum SortType {
 
         /**

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/GqlPublicationStatus.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/publication/GqlPublicationStatus.java
@@ -15,6 +15,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.publication;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.services.content.PublicationInfo;
 
@@ -25,6 +26,7 @@ import java.util.Map;
  * Possible publication statuses of the JCR node.
  */
 @GraphQLName("PublicationStatus")
+@GraphQLDescription("Possible publication statuses of a JCR node")
 public enum GqlPublicationStatus {
 
     PUBLISHED(PublicationInfo.PUBLISHED),

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/wip/GqlJcrWipInfo.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/wip/GqlJcrWipInfo.java
@@ -55,6 +55,7 @@ public class GqlJcrWipInfo {
         return languages;
     }
 
+    @GraphQLDescription("Work in progress status of a JCR node")
     public enum WipStatus {
         @GraphQLDescription("Work in progress disabled")
         DISABLED,


### PR DESCRIPTION
## Summary

Adds a type-level `@GraphQLDescription` to six DXGraphQL enums that had none.

## Why

The new Tag Manager GraphQL backend exposes `JahiaAdminQuery/tagManager/taggedContent` → the full `JCRNode` subgraph. This makes these six pre-existing enums reachable under `JahiaAdminQuery`, where `server-availability-manager`'s schema-description test (`Description for all nodes under JahiaAdminQuery`) requires every graphql-core-registered node to be documented. They had no type-level description, so the SAM nightly reported `expected 8 to equal 0` (see `Jahia/server-availability-manager#251`).

## Changes

Type-level `@GraphQLDescription` added to:
- `MulticriteriaEvaluation`, `GroupingType` (`GroupingHelper`), `SortType` (`SorterHelper`) — predicate
- `PublicationStatus` (`GqlPublicationStatus`), `WipStatus` (`GqlJcrWipInfo`) — publication / wip
- `JCRPropertyType` (`GqlJcrPropertyType`) — node

## Validation

Built `graphql-dxm-provider` from this branch, deployed on a current `jahia-ee-dev:8-SNAPSHOT`, and ran SAM's `apiDescription.spec` → the count of undocumented nodes under `JahiaAdminQuery` dropped from **8 to 2** (the remaining 2 are the `findAvailableNodeName` arguments, owned by jcontent — fixed in a companion PR).

Refs Jahia/server-availability-manager#251
