### PR TITLE
chore: bump version to 3.8.1-SNAPSHOT

### DIFF
--- a/graphql-dxm-provider/pom.xml
+++ b/graphql-dxm-provider/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.8.1-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-dxm-provider</artifactId>
     <name>Jahia GraphQL Core Provider</name>

--- a/graphql-extension-example/pom.xml
+++ b/graphql-extension-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.8.1-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-extension-example</artifactId>
     <name>Jahia GraphQL Extension example</name>

--- a/graphql-test/pom.xml
+++ b/graphql-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-core-root</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.8.1-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-test</artifactId>
     <groupId>org.jahia.test</groupId>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>3.9.0-SNAPSHOT</version>
+            <version>3.8.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <artifactId>graphql-core-root</artifactId>
     <name>Jahia GraphQL Core Root</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>3.8.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the root project for the DX GraphQL Core integration project</description>
 

--- a/tests/jahia-module/misc-test-module/pom.xml
+++ b/tests/jahia-module/misc-test-module/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -55,7 +55,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>graphql-core-test-module-root</artifactId>
     <name>GraphQL Core Test Module Root</name>
-    <version>3.8.0</version>
+    <version>3.8.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 

--- a/tests/jahia-module/scheduler-test-module/pom.xml
+++ b/tests/jahia-module/scheduler-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>

--- a/tests/jahia-module/schema-update-test-module/pom.xml
+++ b/tests/jahia-module/schema-update-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schema-update-test-module</artifactId>

--- a/tests/jahia-module/sdl-test-module/pom.xml
+++ b/tests/jahia-module/sdl-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>


### PR DESCRIPTION
The 3.8.0 release attempt (Jahia/graphql-core#637) was interrupted mid-way: `main` ended up on `3.9.0-SNAPSHOT`, and `graphql-core-test-module-root` (`tests/jahia-module/`) was left pinned at the released `3.8.0`, which already reached Nexus. Retrying `3.8.0` would collide on that already-published test-module artifact.

This rolls both trees back to `3.8.1-SNAPSHOT` — a version that's never touched Nexus — so 3.8.1 can be released cleanly from `main`.

**What changed**
- `graphql-core-root` (root `pom.xml` + `graphql-dxm-provider`, `graphql-extension-example`, `graphql-test`): `3.9.0-SNAPSHOT` → `3.8.1-SNAPSHOT`
- `graphql-core-test-module-root` (`tests/jahia-module/` + its 4 child modules): `3.8.0` → `3.8.1-SNAPSHOT`
- The `jahia-modules` parent version is **unchanged** in every pom.

**Before merging:** the module signature (`jahia-module-signature` in `graphql-dxm-provider/pom.xml`, `graphql-extension-example/pom.xml`, `graphql-test/pom.xml`) needs a keymaker refresh — not done here since keymaker isn't available in the environment that prepared this PR.

Part of Jahia/graphql-core#637