### PR TITLE
fix: treat SDL finder arguments as literal values in the generated JCR-SQL2 query

### DIFF
--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/DateRangeDataFetcher.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/DateRangeDataFetcher.java
@@ -25,6 +25,7 @@ import org.jahia.modules.graphql.provider.dxm.node.SpecializedTypesHandler;
 import org.jahia.modules.graphql.provider.dxm.sdl.SDLUtil;
 import org.jahia.modules.graphql.provider.dxm.sdl.validation.ArgumentValidator;
 import org.jahia.modules.graphql.provider.dxm.security.PermissionHelper;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeIteratorWrapper;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -177,7 +178,7 @@ public class DateRangeDataFetcher extends FinderListDataFetcher {
         }
 
         public String castDate(String value) {
-            return StringUtils.isBlank(value) ? null : "CAST('" + value + "' AS DATE)";
+            return StringUtils.isBlank(value) ? null : "CAST('" + JCRContentUtils.sqlEncode(value) + "' AS DATE)";
         }
 
         public String getStatement() {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/StringFinderDataFetcher.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/StringFinderDataFetcher.java
@@ -17,13 +17,13 @@ package org.jahia.modules.graphql.provider.dxm.sdl.fetchers;
 
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLArgument;
-import org.apache.jackrabbit.util.Text;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.modules.graphql.provider.dxm.node.SpecializedTypesHandler;
 import org.jahia.modules.graphql.provider.dxm.sdl.SDLUtil;
 import org.jahia.modules.graphql.provider.dxm.sdl.validation.ArgumentValidator;
 import org.jahia.modules.graphql.provider.dxm.security.PermissionHelper;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeIteratorWrapper;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -92,15 +92,19 @@ public class StringFinderDataFetcher extends FinderListDataFetcher {
             Map<String, Object> arguments = SDLUtil.getArguments(environment);
             boolean invert = (Boolean) arguments.get(INVERT);
 
-            if (!arguments.containsKey(EQUALS) && !arguments.containsKey(CONTAINS))
+            // an explicitly null argument is not a value to match on
+            String contains = (String) arguments.get(CONTAINS);
+            String equals = (String) arguments.get(EQUALS);
+
+            if (contains == null && equals == null)
                 throw new DataFetchingException(String.format("Entry point %s must have either 'contains' or 'equals' parameter", environment.getFieldDefinition().getName()));
 
-            if (arguments.containsKey(CONTAINS)) {
-                String argument = Text.escapeIllegalXpathSearchChars((String) arguments.get(CONTAINS));
+            if (contains != null) {
+                String argument = JCRContentUtils.sqlEncode(contains);
                 String addOn = invert ? "not" : "";
                 statement = String.format("SELECT * FROM [%s] as n where %s contains(n.[%s], '%s')", type, addOn, finder.getProperty(), argument);
-            } else if (arguments.containsKey(EQUALS)) {
-                String argument = Text.escapeIllegalXpathSearchChars((String) arguments.get(EQUALS));
+            } else {
+                String argument = JCRContentUtils.sqlEncode(equals);
                 String addOn = invert ? "<>" : "=";
                 statement = String.format("SELECT * FROM [%s] as n where n.[%s]%s'%s'", type, finder.getProperty(), addOn, argument);
             }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/WeakreferenceFinderDataFetcher.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/WeakreferenceFinderDataFetcher.java
@@ -95,19 +95,23 @@ public class WeakreferenceFinderDataFetcher extends FinderListDataFetcher {
         try {
             Map<String, Object> arguments = SDLUtil.getArguments(environment);
 
-            if (!arguments.containsKey(PROPERTY) && (!arguments.containsKey(EQUALS) && !arguments.containsKey(CONTAINS)))
+            // an explicitly null argument is not a value to match on
+            String contains = (String) arguments.get(CONTAINS);
+            String equals = (String) arguments.get(EQUALS);
+
+            if (!arguments.containsKey(PROPERTY) && contains == null && equals == null)
                 throw new DataFetchingException(String.format("Entry point %s must have 'property' and either 'contains' or 'equals' parameters", environment.getFieldDefinition().getName()));
 
             String statement = "";
             String weakreferenceProp = Text.escapeIllegalXpathSearchChars((String) arguments.get(PROPERTY));
             boolean invert = (Boolean) arguments.get(INVERT);
 
-            if (arguments.containsKey(CONTAINS)) {
-                String argument = Text.escapeIllegalXpathSearchChars((String) arguments.get(CONTAINS));
+            if (contains != null) {
+                String argument = JCRContentUtils.sqlEncode(contains);
                 String addOn = invert ? "not" : "";
                 statement = String.format("SELECT a.* FROM [%s] as a inner join [%s] as b on a.[%s] = b.['jcr:uuid'] where %s contains(b.['%s'], '%s')", type, ((WeakreferenceFinder) finder).getReferencedType(), finder.getProperty(), addOn, weakreferenceProp, argument);
-            } else if (arguments.containsKey(EQUALS)) {
-                String argument = Text.escapeIllegalXpathSearchChars((String) arguments.get(EQUALS));
+            } else if (equals != null) {
+                String argument = JCRContentUtils.sqlEncode(equals);
                 String addOn = invert ? "<>" : "=";
                 statement = String.format("SELECT a.* FROM [%s] as a inner join [%s] as b on a.[%s] = b.['jcr:uuid'] where b.['%s']%s'%s'", type, ((WeakreferenceFinder) finder).getReferencedType(), finder.getProperty(), weakreferenceProp, addOn, argument);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Backport of #643 onto `2_x`, plus the build fix it needs to be provable here. Two commits, separate
because they have nothing to do with each other.

## 1. The fix — three files

The three SDL finder fetchers each formatted the caller's argument into a single-quoted JCR-SQL2
literal, and did it three different ways, so an argument was not always compared as the text it
actually contains. All three now go through `JCRContentUtils.sqlEncode` — the encoder this module
already uses for every other SQL2 literal it builds.

| Fetcher | Arguments now encoded |
|---|---|
| `StringFinderDataFetcher` | `contains`, `equals` |
| `WeakreferenceFinderDataFetcher` | `contains`, `equals` |
| `DateRangeDataFetcher` | `after`, `before` (via `castDate`) |

Values without an apostrophe are formatted exactly as before. An empty argument becomes usable
(`sqlEncode` is empty-safe) and an explicitly `null` argument is treated as absent. Left alone
deliberately: the `property` argument of `WeakreferenceFinderDataFetcher` is a GraphQL enum built from
the declared schema, already a closed vocabulary.

The cherry-pick applied **without conflict** — the fetchers sit at the same paths here and already
`import org.jahia.services.content.*`, which covers the encoder.

## 2. Why a build fix rides along

**This line's build was broken before this PR, and the first run here proved it:**

```
maven-surefire-plugin:3.6.0-M1:test
  TestNG support requires version 6.14.3 or above. You have declared version 6.9.10
```

`2_x` declares **no version** for `maven-surefire-plugin`, so Maven resolves the newest release — the
build follows an upstream tool nobody here controls. It was green on **2026-02-11**, its last CI run,
and fails today on unchanged code because surefire 3.6.0 raised its TestNG floor above what this line
resolves.

| | result |
|---|---|
| untouched worktree of `2_x`, `mvn test` | **BUILD FAILURE**, that exact message |
| same worktree + this one declaration | **BUILD SUCCESS**, 14 tests, 0 failures |
| this branch | **BUILD SUCCESS**, 14 tests, 0 failures |

Those 14 tests had not run since February. Commit 1 touches no `pom.xml` or `package.json`, so it
cannot have influenced surefire or TestNG resolution.

`${surefire.plugin.version}` is the property the Jahia parent already provides (2.22.2 here) and is the
same declaration `main` carries — no new number to maintain, no change to which tests run. It rides
along rather than going in its own PR because **without it this PR can never show a green build**, so a
reviewer could not approve the fix on evidence.

## 3. No regression spec here, and why

#643 ships a cypress spec. It is **not** carried, and the reason is not caution — it is that this
line's integration environment does not start.

`tests/ci.startup.sh` delegates to `@jahia/cypress` (`^6.4.3` here, `^8.0.0` on the development line),
whose `docker-compose` call leaves an interactive prompt unanswered on the self-hosted runner:

```
Pulling jahia (jahia/jahia-discovery-dev:8.1-SNAPSHOT)...
The image for the service you're trying to recreate has been removed...
Continue with the new image? [yN]
```

The job sat on that prompt from 12:26 to 13:06 and died on the job's 45-minute timeout. Nothing about
the spec was ever evaluated — the environment never came up.

Shipping a spec that has never executed would hand the next person who fixes that tooling a failure
they would reasonably blame on their own change. So the spec, its groovy fixture, and the one-line
test-schema addition that made the string finder reachable are all left out.

**The cost, stated rather than glossed: this line carries no regression coverage for this behaviour, so
it can regress here silently.** That is recorded on our side, not just here. The behavioural proof
for this exact code change lives on the development line, where the spec runs green.

## 4. The red Sonar gate is not this change

`SonarQube Code Analysis` fails on **1066 minutes of added technical debt** and **75 new
maintainability issues**, both required to be 0. This diff is **26 added lines across 4 files**, and
Sonar parsed 4 Java files — three issues per added line is not a plausible reading.

What it is: the scanner could not tell new lines from old ones, so it attributed the whole of each
touched file to this PR. Its own log says so:

```
[WARNING] Shallow clone detected, no blame information will be provided.
[WARNING] Missing blame information for the following files:
```

The 1066 minutes are the debt already sitting in `StringFinderDataFetcher`, `DateRangeDataFetcher` and
`WeakreferenceFinderDataFetcher`, which predate this PR by years.

Two facts that settle it:

- **The identical Java change passed this gate on the development line** (#643, `SonarQube Code Analysis
  pass`). Same three files, same edits.
- **This branch has no required status checks**, so the gate is informational here, not merge-blocking —
  unlike the build, which is why the surefire pin is in this PR and no Sonar change is.

Honestly not determined: *why* blame is available on the development line and not here. Both jobs check
out at `fetch-depth: 1` and both pass the same parameters to the same shared action
(`primary_release_branch`, `github_pr_id`). It most likely turns on server-side analysis history for the
branch, and the SonarQube API answers 401 without credentials — so this is an observation, not an
explanation. The likely fix is one line (`fetch-depth: 0` on that job's checkout) but it is not attempted
here.

## Verification

`mvn -pl graphql-dxm-provider test` on this branch — the `test` phase, i.e. the one CI failed on, not
just `compile`: **14 tests, 0 failures, BUILD SUCCESS**. The `sqlEncode` call sites and the
`CAST('…' AS DATE)` construction were checked in the built sources rather than inferred from a patch
applying quietly.

## Left for whoever owns this line

This backport turned up **three independent infrastructure failures on `2_x`**, none of them caused by
it. One is fixed here because it blocked the build; the other two are left, because neither belongs in a
backport of a behaviour change:

| | state |
|---|---|
| `maven-surefire-plugin` unpinned → build follows latest surefire | **fixed here** (commit 2) |
| `@jahia/cypress` four majors behind (6.4.3 → 8.x) → integration environment cannot start | left — bumping it risks the 31 existing specs across API changes |
| Sonar has no blame data → whole touched files counted as new code | left — one line (`fetch-depth: 0`), not merge-blocking |

Also left: the self-hosted runner is carrying stale docker state from this line's February run, which is
what triggers the compose prompt above. That is hygiene, not code.

Worth knowing while reading that table: **this is the module line shipped to the currently supported
8.1.9 packs.** Until the second row is addressed, no change here can be integration-tested.


