### PR TITLE
fix: scope Tag Manager mutations to the nodes the caller may write

### DIFF
--- a/.chachalog/4JAEpF8G.md
+++ b/.chachalog/4JAEpF8G.md
@@ -1,0 +1,5 @@
+---
+graphql-core: patch
+---
+
+Tag Manager mutations now only write the nodes the caller has rights on, and refuse a replacement tag name that would be stored as an empty tag or as no tag at all. Note one consequence of the per-node scoping: a site-wide rename or delete no longer touches a node that exists only in the live workspace — published, then removed from the edit workspace — so tags left on such nodes are no longer swept by these mutations

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerActionCallback.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerActionCallback.java
@@ -48,6 +48,14 @@ class TagManagerActionCallback implements TagActionCallback<GqlTagWorkspaceMutat
         TagManagerMutationService.flushNodeCaches(node.getPath());
     }
 
+    /**
+     * Counts a node that was left untouched because the caller may not write it. The path is
+     * deliberately not reported: the caller has no right to read it either.
+     */
+    void onSkipped() {
+        failedCount++;
+    }
+
     @Override
     public void onError(JCRNodeWrapper node, RepositoryException e) throws RepositoryException {
         failedCount++;

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerMutationService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerMutationService.java
@@ -21,20 +21,34 @@ import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrWrongInputException;
 import org.jahia.modules.graphql.provider.dxm.service.tags.graphql.GqlTagMutationResult;
 import org.jahia.modules.graphql.provider.dxm.service.tags.graphql.GqlTagWorkspaceMutationResult;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRObservationManager;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.content.JCRSessionWrapper;
+import org.jahia.services.content.nodetypes.NodeTypeRegistry;
 import org.jahia.services.render.filter.cache.ModuleCacheProvider;
 import org.jahia.services.tags.TaggingService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.query.Query;
+import javax.jcr.security.Privilege;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * GraphQL-facing OSGi service that orchestrates tag mutation operations (rename and delete)
@@ -55,7 +69,9 @@ import java.util.List;
  *       per-node errors and continue processing; callers receive a structured result describing
  *       which nodes succeeded and which failed, without a full transaction rollback.</li>
  *   <li><strong>Authorization</strong> – every operation checks that the current user holds the
- *       {@code tagManager} permission on the target site node before performing any write.</li>
+ *       {@code tagManager} permission on the target site node before performing any write, and each
+ *       individual node is additionally checked against the caller's own rights on it — the
+ *       site-level permission opens the screen, it does not widen what the caller may write.</li>
  * </ul>
  *
  * <p><strong>Threading model:</strong> this is a singleton OSGi component. Each public method
@@ -68,7 +84,19 @@ import java.util.List;
  */
 @Component(service = TagManagerMutationService.class, immediate = true)
 public class TagManagerMutationService {
+    private static final Logger logger = LoggerFactory.getLogger(TagManagerMutationService.class);
+
     private static final List<String> WORKSPACES = Arrays.asList(Constants.EDIT_WORKSPACE, Constants.LIVE_WORKSPACE);
+
+    /**
+     * Right the caller must hold on a node for its tag list to be rewritten. The JCR constant carries the
+     * expanded form; the privilege registry expands the prefixed form to the same key before looking it up,
+     * so both spellings resolve identically.
+     */
+    private static final String MODIFY_PROPERTIES_PERMISSION = Privilege.JCR_MODIFY_PROPERTIES;
+
+    /** Selector option of {@code j:tagList} that decides how a tag value is split — the source core reads. */
+    private static final String TAG_SEPARATOR_OPTION = "separator";
 
     /**
      * Maximum number of failure paths included in a single response payload.
@@ -83,11 +111,12 @@ public class TagManagerMutationService {
      * Renames a tag across <em>all</em> nodes in the site that carry it, in both the
      * {@code default} and {@code live} workspaces.
      *
-     * <p>Delegates to {@link TaggingService#renameTagUnderPath} for each workspace, which handles
-     * node iteration and per-node post-processing via {@link TagManagerActionCallback}. JCR
-     * observation listeners are disabled for the entire batch and restored in a {@code finally}
-     * block. Individual node failures do not abort the batch — they are captured in the
-     * returned result with partial-failure semantics.
+     * <p>Iterates the tagged nodes of each workspace and delegates the per-node rewrite to
+     * {@link TaggingService#renameTag(JCRNodeWrapper, String, String)}, with post-processing via
+     * {@link TagManagerActionCallback}. A node the caller may not write is left untouched and
+     * counted as a failure. JCR observation listeners are disabled for the entire batch and
+     * restored in a {@code finally} block. Individual node failures do not abort the batch — they
+     * are captured in the returned result with partial-failure semantics.
      *
      * @param siteKey the Jahia site identifier (e.g. {@code "digitall"}); must not be
      *                {@code null}; authorization is pre-validated by the GraphQL resolver
@@ -103,15 +132,54 @@ public class TagManagerMutationService {
      */
     public GqlTagMutationResult renameTag(String siteKey, String tag, String newName) {
         ensureMutationTagName(newName);
+        return applyUnderSite(siteKey, tag, newName);
+    }
+
+    /**
+     * Removes a tag from <em>all</em> nodes in the site that carry it, in both the
+     * {@code default} and {@code live} workspaces.
+     *
+     * <p>Iterates the tagged nodes of each workspace and delegates the per-node removal to
+     * {@link TaggingService#untag(JCRNodeWrapper, String)}. A node the caller may not write is left
+     * untouched and counted as a failure. Observation listeners are suppressed across both
+     * workspace operations with the same guarantees as {@link #renameTag}. Individual node failures
+     * are captured with partial-failure semantics.
+     *
+     * @param siteKey the Jahia site identifier; must not be {@code null}; authorization is
+     *                pre-validated by the GraphQL resolver
+     * @param tag     the tag value to remove; must not be {@code null} or empty
+     * @return a {@link GqlTagMutationResult} carrying the tag name, a {@code null} node
+     *         identifier (bulk mode), and one {@link GqlTagWorkspaceMutationResult} per workspace
+     * @throws DataFetchingException wrapping a {@link RepositoryException} if session
+     *                               acquisition or query execution fails
+     */
+    public GqlTagMutationResult deleteTag(String siteKey, String tag) {
+        return applyUnderSite(siteKey, tag, null);
+    }
+
+    /**
+     * Shared body of the two site-wide operations: rename when {@code newName} is non-{@code null},
+     * removal otherwise.
+     *
+     * <p>The writes stay on a system session — the {@code live} copy is updated in the same pass, and
+     * the caller is not expected to hold live write rights — so every candidate node is checked
+     * against the caller's own view of it before it is touched (see
+     * {@link #isModifiableByCaller(JCRSessionWrapper, String)}). The verdict depends only on the
+     * identifier and the caller's session, both of which are the same for the two workspace passes,
+     * so it is computed once per node and reused.
+     */
+    private GqlTagMutationResult applyUnderSite(String siteKey, String tag, String newName) {
         String sitePath = "/sites/" + siteKey;
         try {
+            JCRSessionWrapper callerSession = JCRSessionFactory.getInstance().getCurrentUserSession(Constants.EDIT_WORKSPACE);
+            Map<String, Boolean> modifiableByCaller = new HashMap<>();
             List<GqlTagWorkspaceMutationResult> results = new ArrayList<>();
 
             JCRObservationManager.setAllEventListenersDisabled(Boolean.TRUE);
             try {
                 for (String workspace : WORKSPACES) {
                     JCRSessionWrapper systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession(workspace, null, null);
-                    results.add(taggingService.renameTagUnderPath(sitePath, systemSession, tag, newName, new TagManagerActionCallback(systemSession, workspace)));
+                    results.add(applyInWorkspace(systemSession, callerSession, modifiableByCaller, workspace, sitePath, tag, newName));
                 }
             } finally {
                 JCRObservationManager.setAllEventListenersDisabled(Boolean.FALSE);
@@ -123,41 +191,37 @@ public class TagManagerMutationService {
         }
     }
 
-    /**
-     * Removes a tag from <em>all</em> nodes in the site that carry it, in both the
-     * {@code default} and {@code live} workspaces.
-     *
-     * <p>Delegates to {@link TaggingService#deleteTagUnderPath} for each workspace. Observation
-     * listeners are suppressed across both workspace operations with the same guarantees as
-     * {@link #renameTag}. Individual node failures are captured with partial-failure semantics.
-     *
-     * @param siteKey the Jahia site identifier; must not be {@code null}; authorization is
-     *                pre-validated by the GraphQL resolver
-     * @param tag     the tag value to remove; must not be {@code null} or empty
-     * @return a {@link GqlTagMutationResult} carrying the tag name, a {@code null} node
-     *         identifier (bulk mode), and one {@link GqlTagWorkspaceMutationResult} per workspace
-     * @throws DataFetchingException wrapping a {@link RepositoryException} if session
-     *                               acquisition or query execution fails
-     */
-    public GqlTagMutationResult deleteTag(String siteKey, String tag) {
-        String sitePath = "/sites/" + siteKey;
-        try {
-            List<GqlTagWorkspaceMutationResult> results = new ArrayList<>();
-
-            JCRObservationManager.setAllEventListenersDisabled(Boolean.TRUE);
+    private GqlTagWorkspaceMutationResult applyInWorkspace(JCRSessionWrapper systemSession, JCRSessionWrapper callerSession,
+                                                           Map<String, Boolean> modifiableByCaller, String workspace,
+                                                           String sitePath, String tag, String newName) throws RepositoryException {
+        TagManagerActionCallback callback = new TagManagerActionCallback(systemSession, workspace);
+        NodeIterator taggedNodes = queryTaggedNodes(systemSession, sitePath, tag);
+        while (taggedNodes.hasNext()) {
+            JCRNodeWrapper node = (JCRNodeWrapper) taggedNodes.nextNode();
             try {
-                for (String workspace : WORKSPACES) {
-                    JCRSessionWrapper systemSession = JCRSessionFactory.getInstance().getCurrentSystemSession(workspace, null, null);
-                    results.add(taggingService.deleteTagUnderPath(sitePath, systemSession, tag, new TagManagerActionCallback(systemSession, workspace)));
+                if (!modifiableByCaller.computeIfAbsent(node.getIdentifier(), id -> isModifiableByCaller(callerSession, id))) {
+                    callback.onSkipped();
+                    continue;
                 }
-            } finally {
-                JCRObservationManager.setAllEventListenersDisabled(Boolean.FALSE);
+                if (newName != null) {
+                    taggingService.renameTag(node, tag, newName);
+                } else {
+                    taggingService.untag(node, tag);
+                }
+                callback.afterTagAction(node);
+            } catch (RepositoryException e) {
+                callback.onError(node, e);
             }
-
-            return new GqlTagMutationResult(tag, null, results);
-        } catch (RepositoryException e) {
-            throw new DataFetchingException(e);
         }
+        return callback.end();
+    }
+
+    private NodeIterator queryTaggedNodes(JCRSessionWrapper session, String sitePath, String tag) throws RepositoryException {
+        String statement = "SELECT * FROM [jmix:tagged] AS result WHERE ISDESCENDANTNODE(result, '" +
+                JCRContentUtils.sqlEncode(sitePath) + "') AND (result.[j:tagList] = $tag)";
+        Query query = session.getWorkspace().getQueryManager().createQuery(statement, Query.JCR_SQL2);
+        query.bindValue("tag", session.getValueFactory().createValue(tag));
+        return query.execute().getNodes();
     }
 
     /**
@@ -187,6 +251,7 @@ public class TagManagerMutationService {
         try {
             JCRSessionWrapper editSession = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, null, null);
             validateNodeBelongsToSite(editSession, nodeId, sitePath);
+            ensureCallerCanModify(nodeId);
             List<GqlTagWorkspaceMutationResult> workspaceResults = new ArrayList<>();
 
             JCRObservationManager.setAllEventListenersDisabled(Boolean.TRUE);
@@ -251,6 +316,7 @@ public class TagManagerMutationService {
         try {
             JCRSessionWrapper editSession = JCRSessionFactory.getInstance().getCurrentSystemSession(Constants.EDIT_WORKSPACE, null, null);
             validateNodeBelongsToSite(editSession, nodeId, sitePath);
+            ensureCallerCanModify(nodeId);
             List<GqlTagWorkspaceMutationResult> workspaceResults = new ArrayList<>();
 
             JCRObservationManager.setAllEventListenersDisabled(Boolean.TRUE);
@@ -292,6 +358,59 @@ public class TagManagerMutationService {
         cacheProvider.flushRegexpDependenciesOfPath(path, true);
     }
 
+    /**
+     * Rejects a single-node operation the caller has no right to perform on that node.
+     *
+     * @param nodeIdentifier the JCR UUID of the node about to be written
+     * @throws DataFetchingException if the caller may not write the node's properties
+     */
+    private void ensureCallerCanModify(String nodeIdentifier) throws RepositoryException {
+        JCRSessionWrapper callerSession = JCRSessionFactory.getInstance().getCurrentUserSession(Constants.EDIT_WORKSPACE);
+        if (!isModifiableByCaller(callerSession, nodeIdentifier)) {
+            throw new DataFetchingException("Permission denied");
+        }
+    }
+
+    /**
+     * Reports whether the caller may rewrite the tag list of a node, resolving it in the caller's own
+     * ACL-bounded session so the node's access control is honoured rather than the system session's
+     * unrestricted rights.
+     *
+     * <p>The {@code default} workspace is the authority for both workspaces: the live copy is updated by
+     * the same operation to keep the two in sync, and a caller who may edit content is not expected to
+     * hold live write rights. A node the caller cannot resolve there at all — unreadable, or no longer
+     * present in the edit workspace — is reported as not modifiable.
+     */
+    private boolean isModifiableByCaller(JCRSessionWrapper callerSession, String nodeIdentifier) {
+        try {
+            return callerSession.getNodeByIdentifier(nodeIdentifier).hasPermission(MODIFY_PROPERTIES_PERMISSION);
+        } catch (RepositoryException e) {
+            // Resolving an identifier walks every store provider and reports whatever went wrong as a
+            // missing item, so the exception TYPE cannot separate an access decision from an
+            // infrastructure failure — only the cause can: a node that is simply absent or unreadable
+            // arrives with no cause (or a missing-item one), while a provider that broke arrives wrapped.
+            // The answer stays fail-closed either way, but a bulk run reporting "30 failed" must not
+            // hide a store outage at DEBUG, since the paths are deliberately not reported.
+            if (isExpectedAbsence(e.getCause())) {
+                logger.debug("Node {} left untouched: the caller's session cannot resolve it", nodeIdentifier, e);
+            } else {
+                logger.warn("Node {} left untouched: resolving it in the caller's session failed unexpectedly", nodeIdentifier, e);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Reports whether a wrapped resolution failure is the ordinary "the caller cannot see this node" case
+     * rather than something that went wrong underneath it.
+     */
+    private static boolean isExpectedAbsence(Throwable cause) {
+        return cause == null
+                || cause instanceof ItemNotFoundException
+                || cause instanceof PathNotFoundException
+                || cause instanceof AccessDeniedException;
+    }
+
     private void validateNodeBelongsToSite(JCRSessionWrapper session, String nodeId, String sitePath) throws RepositoryException {
         JCRNodeWrapper node = session.getNodeByIdentifier(nodeId);
         String nodePath = node.getPath();
@@ -300,9 +419,52 @@ public class TagManagerMutationService {
         }
     }
 
+    /**
+     * Rejects a replacement tag name that would end up empty once written.
+     *
+     * <p>The check is made on the values that actually reach {@code j:tagList}, not on the argument:
+     * {@link TaggingService} splits the replacement on the property's own separator and runs the
+     * configured {@code TagHandler} on each segment, so inspecting the whole string lets two shapes
+     * through — one that stores an empty tag value, and one whose segment list comes out empty, which
+     * drops the renamed tag with no replacement. Both are what this guard exists to prevent.
+     *
+     * @param newName the replacement tag value
+     * @throws GqlJcrWrongInputException if the value is blank, or yields no usable tag once stored
+     */
     private void ensureMutationTagName(String newName) {
         if (StringUtils.isBlank(newName)) {
             throw new GqlJcrWrongInputException("Argument 'newName' can't be empty");
+        }
+        List<String> storedValues = storedTagValues(newName);
+        if (storedValues.isEmpty() || storedValues.stream().anyMatch(StringUtils::isBlank)) {
+            throw new GqlJcrWrongInputException("Argument 'newName' can't be empty");
+        }
+    }
+
+    /**
+     * Values the replacement name will be stored as, derived the way {@link TaggingService} derives them:
+     * split on the {@code j:tagList} separator, each segment run through the configured tag handler.
+     */
+    private List<String> storedTagValues(String newName) {
+        String separator = tagSeparator();
+        String[] segments = separator != null ? newName.split(separator) : new String[] { newName };
+        return Arrays.stream(segments)
+                .map(segment -> taggingService.getTagHandler().execute(segment))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Separator declared on the {@code j:tagList} property definition, read from the same selector option
+     * {@link TaggingService} reads at startup. A repository without the mixin yields {@code null}, which
+     * means "no split", matching how the tagging service behaves when the option is absent.
+     */
+    private String tagSeparator() {
+        try {
+            return NodeTypeRegistry.getInstance().getNodeType(TaggingService.JMIX_TAGGED)
+                    .getPropertyDefinition(TaggingService.J_TAG_LIST).getSelectorOptions().get(TAG_SEPARATOR_OPTION);
+        } catch (NoSuchNodeTypeException e) {
+            logger.debug("Node type {} is not registered, so no tag separator applies", TaggingService.JMIX_TAGGED, e);
+            return null;
         }
     }
 }

--- a/tests/cypress/e2e/api/tagManager.cy.ts
+++ b/tests/cypress/e2e/api/tagManager.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, createUser, deleteSite, deleteUser, publishAndWaitJobEnding} from '@jahia/cypress';
-import {grantUserRole} from '../../fixtures/acl';
+import {grantUserRole, revokeUserRole} from '../../fixtures/acl';
 
 /**
  * End-to-end tests for the Tag Manager GraphQL API.
@@ -9,6 +9,8 @@ import {grantUserRole} from '../../fixtures/acl';
  *  - Mutation happy paths: renameTag, deleteTag, renameTagOnNode, deleteTagOnNode
  *  - Dual-workspace propagation (EDIT + LIVE)
  *  - Authorization failures (user without tagManager permission, wrong site key)
+ *  - Per-node write rights: a caller holding tagManager still only writes the nodes it may write
+ *  - Candidate selection: a tag carrying a quote is matched by the same rule as on the read side
  */
 describe('Tag Manager GraphQL API', () => {
     const siteKey = 'tagManagerTestSite';
@@ -202,6 +204,42 @@ describe('Tag Manager GraphQL API', () => {
             });
         });
 
+        // The candidate nodes are selected by binding the tag as a query parameter, the same way the
+        // read side does, so a tag carrying a quote is matched by one rule on both sides.
+        it('renames a tag containing a quote on all nodes that carry it', () => {
+            const quotedTag = 'o\'brien';
+
+            addNode({
+                parentPathOrId: `/sites/${siteKey}/contents`,
+                name: 'quotedTagNode',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:tagged'],
+                properties: [
+                    {name: 'j:tagList', values: [quotedTag], type: 'STRING'}
+                ]
+            });
+
+            cy.apollo({
+                mutationFile: 'tagManager/renameTag.graphql',
+                variables: {siteKey, tag: quotedTag, newName: 'obrien-renamed'}
+            }).should((result: any) => {
+                const workspaceResults = result.data.admin.jahia.tagManager.renameTag.workspaceResults;
+                // eslint-disable-next-line max-nested-callbacks
+                const editResult = workspaceResults.find((wsResult: any) => wsResult.workspace === 'default');
+                expect(editResult.processedCount, 'the quoted tag selects its node').to.equal(1);
+                expect(editResult.failedCount).to.equal(0);
+            });
+
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'obrien-renamed'}
+            }).should((result: any) => {
+                // eslint-disable-next-line max-nested-callbacks
+                const paths = result.data.admin.jahia.tagManager.taggedContent.nodes.map((node: any) => node.path);
+                expect(paths).to.include(`/sites/${siteKey}/contents/quotedTagNode`);
+            });
+        });
+
         it('returns an error when newName is blank', () => {
             cy.apollo({
                 mutationFile: 'tagManager/renameTag.graphql',
@@ -211,6 +249,31 @@ describe('Tag Manager GraphQL API', () => {
                 expect(result.errors).to.exist.and.not.be.empty;
             });
         });
+
+        // The stored value is one tag per segment of the separator, each normalized on its own, so a name
+        // that is non-blank as a whole can still store an empty tag — or no tag at all, which would drop
+        // the renamed tag with nothing in its place.
+        for (const newName of [' , ', ',']) {
+            it(`returns an error when newName yields no usable tag (${JSON.stringify(newName)})`, () => {
+                cy.apollo({
+                    mutationFile: 'tagManager/renameTag.graphql',
+                    variables: {siteKey, tag: 'alpha', newName},
+                    errorPolicy: 'all'
+                }).should((result: any) => {
+                    expect(result.errors, 'the mutation is refused').to.exist.and.not.be.empty;
+                });
+
+                // As root: 'alpha' is still there, so nothing was renamed away
+                cy.apollo({
+                    queryFile: 'tagManager/getTags.graphql',
+                    variables: {siteKey}
+                }).should((result: any) => {
+                    // eslint-disable-next-line max-nested-callbacks
+                    const names = result.data.admin.jahia.tagManager.tags.nodes.map((t: any) => t.name);
+                    expect(names).to.include('alpha');
+                });
+            });
+        }
 
         it('denies bulk rename for a user without tagManager permission', () => {
             cy.apolloClient({username: unauthorizedUser, password})
@@ -388,6 +451,173 @@ describe('Tag Manager GraphQL API', () => {
                     expect(result.errors).to.exist.and.not.be.empty;
                     expect(result.data?.admin?.jahia?.tagManager).to.not.exist;
                 });
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // PER-NODE WRITE RIGHTS
+    //
+    // Holding tagManager on the site opens the Tag Manager; it does not make every node
+    // under the site writable. A node the caller's roles are denied on is out of reach and
+    // must keep its tags, in BOTH workspaces — the live copy is updated by the same
+    // operation, so the edit workspace decides for both.
+    // ────────────────────────────────────────────────────────────────────────────
+
+    describe('per-node write rights', () => {
+        const tagManagerUser = 'tagManagerScoped';
+        const restrictedNodePath = `/sites/${siteKey}/contents/restrictedNode`;
+        let restrictedNodeUuid: string;
+
+        before('Create a tag-manager user, a reachable node and an out-of-reach node', () => {
+            createUser(tagManagerUser, password);
+            // The server-administrator role carries the admin GraphQL entry permissions
+            // (graphqlAdminQuery / graphqlAdminMutation); site-administrator carries tagManager
+            // plus jcr:all_default on the site, which a per-node DENY takes back
+            grantUserRole('/', 'server-administrator', tagManagerUser);
+            grantUserRole(`/sites/${siteKey}`, 'site-administrator', tagManagerUser);
+
+            addNode({
+                parentPathOrId: `/sites/${siteKey}/contents`,
+                name: 'reachableNode',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:tagged'],
+                properties: [
+                    {name: 'j:tagList', values: ['scoped'], type: 'STRING'}
+                ]
+            });
+
+            addNode({
+                parentPathOrId: `/sites/${siteKey}/contents`,
+                name: 'restrictedNode',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:tagged'],
+                properties: [
+                    {name: 'j:tagList', values: ['restricted'], type: 'STRING'}
+                ]
+            }).then((result: any) => {
+                restrictedNodeUuid = result.data.jcr.addNode.uuid;
+                // Publish first, so the tag exists in both workspaces...
+                publishAndWaitJobEnding(restrictedNodePath);
+                // ...then DENY both roles on this node only, putting it out of the user's reach
+                // while tagManager on the site itself is untouched
+                revokeUserRole(restrictedNodePath, 'site-administrator', tagManagerUser);
+                revokeUserRole(restrictedNodePath, 'server-administrator', tagManagerUser);
+            });
+        });
+
+        after('Remove the test user', () => {
+            deleteUser(tagManagerUser);
+        });
+
+        it('renames a tag the caller may write (site-wide)', () => {
+            cy.apolloClient({username: tagManagerUser, password})
+                .apollo({
+                    mutationFile: 'tagManager/renameTag.graphql',
+                    variables: {siteKey, tag: 'scoped', newName: 'scoped-renamed'}
+                }).should((result: any) => {
+                    const workspaceResults = result.data.admin.jahia.tagManager.renameTag.workspaceResults;
+                    // eslint-disable-next-line max-nested-callbacks
+                    const editResult = workspaceResults.find((wsResult: any) => wsResult.workspace === 'default');
+                    expect(editResult.processedCount).to.equal(1);
+                    expect(editResult.failedCount).to.equal(0);
+                });
+
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'scoped-renamed'}
+            }).should((result: any) => {
+                const nodes = result.data.admin.jahia.tagManager.taggedContent.nodes;
+                expect(nodes).to.have.length(1);
+                expect(nodes[0].path).to.equal(`/sites/${siteKey}/contents/reachableNode`);
+            });
+        });
+
+        it('leaves a node the caller may not write untouched on a site-wide rename', () => {
+            cy.apolloClient({username: tagManagerUser, password})
+                .apollo({
+                    mutationFile: 'tagManager/renameTag.graphql',
+                    variables: {siteKey, tag: 'restricted', newName: 'restricted-renamed'}
+                }).should((result: any) => {
+                    const workspaceResults = result.data.admin.jahia.tagManager.renameTag.workspaceResults;
+                    // eslint-disable-next-line max-nested-callbacks
+                    const processed = workspaceResults.reduce((total: number, wsResult: any) => total + wsResult.processedCount, 0);
+                    // eslint-disable-next-line max-nested-callbacks
+                    const failed = workspaceResults.reduce((total: number, wsResult: any) => total + wsResult.failedCount, 0);
+                    expect(processed, 'no node is written').to.equal(0);
+                    expect(failed, 'the out-of-reach node is reported as a failure').to.be.greaterThan(0);
+                });
+
+            // As root: the tag is still on the node, under its original name
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'restricted'}
+            }).should((result: any) => {
+                // eslint-disable-next-line max-nested-callbacks
+                const paths = result.data.admin.jahia.tagManager.taggedContent.nodes.map((node: any) => node.path);
+                expect(paths).to.include(restrictedNodePath);
+            });
+        });
+
+        it('leaves a node the caller may not write untouched on a site-wide delete', () => {
+            cy.apolloClient({username: tagManagerUser, password})
+                .apollo({
+                    mutationFile: 'tagManager/deleteTag.graphql',
+                    variables: {siteKey, tag: 'restricted'}
+                }).should((result: any) => {
+                    const workspaceResults = result.data.admin.jahia.tagManager.deleteTag.workspaceResults;
+                    // eslint-disable-next-line max-nested-callbacks
+                    const processed = workspaceResults.reduce((total: number, wsResult: any) => total + wsResult.processedCount, 0);
+                    expect(processed, 'no node is written').to.equal(0);
+                });
+
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'restricted'}
+            }).should((result: any) => {
+                // eslint-disable-next-line max-nested-callbacks
+                const paths = result.data.admin.jahia.tagManager.taggedContent.nodes.map((node: any) => node.path);
+                expect(paths).to.include(restrictedNodePath);
+            });
+        });
+
+        it('rejects renameTagOnNode on a node the caller may not write', () => {
+            cy.apolloClient({username: tagManagerUser, password})
+                .apollo({
+                    mutationFile: 'tagManager/renameTagOnNode.graphql',
+                    variables: {siteKey, tag: 'restricted', newName: 'restricted-renamed', nodeId: restrictedNodeUuid},
+                    errorPolicy: 'all'
+                }).should((result: any) => {
+                    expect(result.errors).to.exist.and.not.be.empty;
+                });
+
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'restricted'}
+            }).should((result: any) => {
+                // eslint-disable-next-line max-nested-callbacks
+                const paths = result.data.admin.jahia.tagManager.taggedContent.nodes.map((node: any) => node.path);
+                expect(paths).to.include(restrictedNodePath);
+            });
+        });
+
+        it('rejects deleteTagOnNode on a node the caller may not write', () => {
+            cy.apolloClient({username: tagManagerUser, password})
+                .apollo({
+                    mutationFile: 'tagManager/deleteTagOnNode.graphql',
+                    variables: {siteKey, tag: 'restricted', nodeId: restrictedNodeUuid},
+                    errorPolicy: 'all'
+                }).should((result: any) => {
+                    expect(result.errors).to.exist.and.not.be.empty;
+                });
+
+            cy.apollo({
+                queryFile: 'tagManager/getTaggedContent.graphql',
+                variables: {siteKey, tag: 'restricted'}
+            }).should((result: any) => {
+                // eslint-disable-next-line max-nested-callbacks
+                const paths = result.data.admin.jahia.tagManager.taggedContent.nodes.map((node: any) => node.path);
+                expect(paths).to.include(restrictedNodePath);
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

Maintenance-line counterpart of [graphql-core#650](https://github.com/Jahia/graphql-core/pull/650), which landed on `main` as `bdac609a`. This line carries the same Tag Manager backend, so it carries the same two defects: the mutations write on a system session with only the site-level `tagManager` permission consulted, and the replacement-name check inspects the whole argument rather than the values that reach `j:tagList`.

`8.2.3` and `8.2.2` both pin `graphql-dxm-provider 3.8.1`, so one release off this branch serves both.

## Change

A cherry-pick of `bdac609a`, applied with no conflict, four files. The two guard methods land byte-identical to `main`:

- every candidate node is resolved in the **caller's own** session and checked for `jcr:modifyProperties` before it is touched; the system session still performs the write, because the `default` and `live` copies are updated in one pass and the caller is not expected to hold live write rights;
- a node the caller may not write is left untouched and counted in `failedCount` **without its path**, since the caller may not be able to read it either;
- `ensureMutationTagName` derives the stored values the way `TaggingService` does — split on the `j:tagList` separator, each segment normalized by the configured tag handler — so a name that would be stored as an empty tag, or that leaves no segment at all and therefore drops the renamed tag with no replacement, is refused;
- the per-node verdict logs an unexpected resolution failure at WARN and an ordinary absence at DEBUG, fail-closed either way.

Scope is the four mutations: `renameTag` / `deleteTag` site-wide and `renameTagOnNode` / `deleteTagOnNode`.

## Verification

**The spec travels.** This line has a `tests/` tree, so `tests/cypress/e2e/api/tagManager.cy.ts` comes across unchanged — the per-node rights block and the two replacement-name cases included. That is what CI runs here.

Measured on the development line, same spec, published artifacts on one instance with the bundle as the only variable:

| Bundle | Result |
|---|---|
| before the change (`3.9.0-20260731.083616-3`) | 21 passing, **7 failing** |
| with the change (`3.9.0-20260806.085757-4`) | **28/28** |

Locally on **this** line, the cherry-pick compiles (`graphql-dxm-provider-3.8.1.jar` builds) — the run that matters for the merge is this PR's own CI, since the spec is here.

## Note on the base branch

`3_8_x` did not exist: 3.8.1 was cut from `main`, and the maintenance branches were `1_x`, `2_8_x`, `2_19_x`, `2_x`. It was created from tag `3_8_1` so this change has somewhere to land; the release cut and the two pack pin bumps on `JAHIA-8-2-3-X-BRANCH` and `JAHIA-8-2-2-X-BRANCH` follow separately.
