### PR TITLE
fix: added document limit to gql queries

### DIFF
--- a/.chachalog/Nq4vZ7Rt.md
+++ b/.chachalog/Nq4vZ7Rt.md
@@ -1,0 +1,5 @@
+---
+graphql-core: minor
+---
+
+The number of nodes a single GraphQL request may read is now bounded by a new configuration property, `graphql.fields.node.requestLimit` (default `20000`, `0` disables).

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/config/DXGraphQLConfig.java
@@ -45,6 +45,7 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
 
     private static final String CORS_ORIGINS = "http.cors.allow-origin";
     private static final String NODE_LIMIT = "graphql.fields.node.limit";
+    private static final String REQUEST_NODE_LIMIT = "graphql.fields.node.requestLimit";
     private static final String MAX_QUERY_COMPLEXITY = "graphql.query.maxComplexity";
     private static final String MAX_QUERY_DEPTH = "graphql.query.maxDepth";
     private static final String MUTATION_BATCH_LIMIT = "graphql.mutation.batch.limit";
@@ -68,11 +69,13 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
     // that source stops providing a value (property removed, or config deleted) the effective value reverts to the
     // code default instead of sticking at the last value that was ever set.
     private final Map<String, Integer> nodeLimitByPid = new ConcurrentHashMap<>();
+    private final Map<String, Integer> requestNodeLimitByPid = new ConcurrentHashMap<>();
     private final Map<String, Integer> maxQueryComplexityByPid = new ConcurrentHashMap<>();
     private final Map<String, Integer> maxQueryDepthByPid = new ConcurrentHashMap<>();
     private final Map<String, Integer> mutationBatchLimitByPid = new ConcurrentHashMap<>();
 
     private volatile int nodeLimit = DEFAULT_NODE_LIMIT;
+    private volatile int requestNodeLimit = PaginationHelper.DEFAULT_REQUEST_NODE_LIMIT;
     private volatile int maxQueryComplexity = 0;
     private volatile int maxQueryDepth = 0;
     private volatile int mutationBatchLimit = GraphQLLimits.DEFAULT_MUTATION_BATCH_LIMIT;
@@ -101,6 +104,7 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         Map<String, String> newPermissions = new HashMap<>();
         Set<String> newCorsOrigins = null;
         Integer newNodeLimit = null;
+        Integer newRequestNodeLimit = null;
         Integer newMaxQueryComplexity = null;
         Integer newMaxQueryDepth = null;
         Integer newMutationBatchLimit = null;
@@ -131,6 +135,12 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
             } else if (key.equals(NODE_LIMIT)) {
                 if (isDefaultConfig) {
                     newNodeLimit = parseNonNegativeLimit(key, value, "Node limit");
+                } else {
+                    warnGatedPropertyIgnored(key, pid);
+                }
+            } else if (key.equals(REQUEST_NODE_LIMIT)) {
+                if (isDefaultConfig) {
+                    newRequestNodeLimit = parseNonNegativeLimit(key, value, "Request node limit");
                 } else {
                     warnGatedPropertyIgnored(key, pid);
                 }
@@ -173,6 +183,9 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         if (newNodeLimit != null) {
             nodeLimitByPid.put(pid, newNodeLimit);
         }
+        if (newRequestNodeLimit != null) {
+            requestNodeLimitByPid.put(pid, newRequestNodeLimit);
+        }
         if (newMaxQueryComplexity != null) {
             maxQueryComplexityByPid.put(pid, newMaxQueryComplexity);
         }
@@ -210,6 +223,7 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         corsOriginByPid.remove(pid);
         introspectionCheckByPid.remove(pid);
         nodeLimitByPid.remove(pid);
+        requestNodeLimitByPid.remove(pid);
         maxQueryComplexityByPid.remove(pid);
         maxQueryDepthByPid.remove(pid);
         mutationBatchLimitByPid.remove(pid);
@@ -231,6 +245,12 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
         if (newNodeLimit != nodeLimit) {
             nodeLimit = newNodeLimit;
             PaginationHelper.updateLimit(nodeLimit);
+        }
+
+        int newRequestNodeLimit = firstValueOrDefault(requestNodeLimitByPid, PaginationHelper.DEFAULT_REQUEST_NODE_LIMIT);
+        if (newRequestNodeLimit != requestNodeLimit) {
+            requestNodeLimit = newRequestNodeLimit;
+            PaginationHelper.updateRequestLimit(requestNodeLimit);
         }
         maxQueryComplexity = firstValueOrDefault(maxQueryComplexityByPid, 0);
         maxQueryDepth = firstValueOrDefault(maxQueryDepthByPid, 0);
@@ -336,6 +356,13 @@ public class DXGraphQLConfig implements ManagedServiceFactory {
 
     public int getNodeLimit() {
         return nodeLimit;
+    }
+
+    /**
+     * @return the number of nodes one request may walk across all of its fields together; {@code 0} means unbounded
+     */
+    public int getRequestNodeLimit() {
+        return requestNodeLimit;
     }
 
     /**

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentationProvider.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/JCRInstrumentationProvider.java
@@ -20,6 +20,7 @@ import graphql.execution.instrumentation.Instrumentation;
 import graphql.kickstart.execution.config.InstrumentationProvider;
 import org.jahia.modules.graphql.provider.dxm.config.DXGraphQLConfig;
 import org.jahia.modules.graphql.provider.dxm.config.GraphQLLimits;
+import org.jahia.modules.graphql.provider.dxm.relay.PaginationHelper;
 import org.osgi.service.component.annotations.*;
 
 import java.util.ArrayList;
@@ -62,10 +63,12 @@ public class JCRInstrumentationProvider implements InstrumentationProvider {
         int maxQueryComplexity = dxGraphQLConfig.getMaxQueryComplexity();
         int maxQueryDepth = dxGraphQLConfig.getMaxQueryDepth();
         // Read the batch bound from GraphQLLimits rather than the config directly, so that this guard and the per-field
-        // check in the mutation resolvers can never disagree about the value in force.
+        // check in the mutation resolvers can never disagree about the value in force. The node allowance is read from
+        // PaginationHelper for the same reason: it is spent there, as the connections walk.
         int maxMutationBatchSize = GraphQLLimits.getMutationBatchLimit();
-        if (maxQueryComplexity > 0 || maxQueryDepth > 0 || maxMutationBatchSize > 0) {
-            instns.add(new QueryCostInstrumentation(maxQueryComplexity, maxQueryDepth, maxMutationBatchSize));
+        int maxNodesPerRequest = PaginationHelper.getRequestNodeLimit();
+        if (maxQueryComplexity > 0 || maxQueryDepth > 0 || maxMutationBatchSize > 0 || maxNodesPerRequest > 0) {
+            instns.add(new QueryCostInstrumentation(maxQueryComplexity, maxQueryDepth, maxMutationBatchSize, maxNodesPerRequest));
         }
 
         instns.add(new JCRInstrumentation(dxGraphQLConfig));

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/QueryCostInstrumentation.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/instrumentation/QueryCostInstrumentation.java
@@ -20,6 +20,7 @@ import graphql.execution.AbortExecutionException;
 import graphql.execution.ExecutionContext;
 import graphql.language.OperationDefinition;
 import org.jahia.modules.graphql.provider.dxm.config.GraphQLLimits;
+import org.jahia.modules.graphql.provider.dxm.relay.PaginationHelper;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
 import graphql.execution.instrumentation.SimpleInstrumentationContext;
@@ -40,6 +41,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * traverser re-expands a fragment definition at each spread of it, so a guard that traverses repeatedly multiplies
  * exactly the cost it exists to bound.
  *
+ * <p>It also opens the request's node allowance, the one bound here that is not a verdict on the document: the guards
+ * above reject a selection for its shape, whereas the allowance limits how far that shape may expand once it is walking
+ * actual content, and so can only be spent as the fields run.
+ *
  * <p>A limit of 0 or less disables that individual check. The messages keep graphql-java's wording, whose enforcement
  * this class took over from {@link graphql.analysis.MaxQueryComplexityInstrumentation} and
  * {@link graphql.analysis.MaxQueryDepthInstrumentation}, so existing clients and log filters are unaffected.
@@ -51,17 +56,20 @@ public class QueryCostInstrumentation extends SimplePerformantInstrumentation {
     private final int maxComplexity;
     private final int maxDepth;
     private final int maxBatchSize;
+    private final int maxNodesPerRequest;
 
     /**
-     * @param maxComplexity maximum number of selected fields, 0 to disable that check
-     * @param maxDepth      maximum nesting depth, 0 to disable that check
-     * @param maxBatchSize  maximum number of items a mutation may be handed in list arguments across the whole
-     *                      document, 0 to disable that check
+     * @param maxComplexity      maximum number of selected fields, 0 to disable that check
+     * @param maxDepth           maximum nesting depth, 0 to disable that check
+     * @param maxBatchSize       maximum number of items a mutation may be handed in list arguments across the whole
+     *                           document, 0 to disable that check
+     * @param maxNodesPerRequest maximum number of nodes the request's fields may walk in total, 0 to disable that bound
      */
-    public QueryCostInstrumentation(int maxComplexity, int maxDepth, int maxBatchSize) {
+    public QueryCostInstrumentation(int maxComplexity, int maxDepth, int maxBatchSize, int maxNodesPerRequest) {
         this.maxComplexity = maxComplexity;
         this.maxDepth = maxDepth;
         this.maxBatchSize = maxBatchSize;
+        this.maxNodesPerRequest = maxNodesPerRequest;
     }
 
     @Override
@@ -94,6 +102,15 @@ public class QueryCostInstrumentation extends SimplePerformantInstrumentation {
             // query-driven mutation draws from what this request has left instead of from the full limit each time.
             executionContext.getGraphQLContext().put(GraphQLLimits.REMAINING_BATCH_ALLOWANCE,
                     new AtomicInteger(maxBatchSize - cost.getBatchSize()));
+        }
+        // Opens the request's node allowance, which the connections draw down as they walk the repository. Unlike the
+        // three bounds above this one cannot be settled here: how many nodes a field reaches is a property of the
+        // content, not of the document, and only becomes known as the fields run. What the document analysis above
+        // can bound is the shape of a selection; what this bounds is how far that shape expands once pointed at a
+        // repository - the dimension along which a small, shallow, legal document still multiplies out.
+        if (maxNodesPerRequest > 0) {
+            executionContext.getGraphQLContext().put(PaginationHelper.REMAINING_NODE_ALLOWANCE,
+                    new AtomicInteger(maxNodesPerRequest));
         }
         return SimpleInstrumentationContext.noOp();
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrNodeImpl.java
@@ -466,8 +466,16 @@ public class GqlJcrNodeImpl implements GqlJcrNode {
     }
 
     private void collectReferences(PropertyIterator references, Collection<GqlJcrProperty> gqlReferences, DataFetchingEnvironment environment) throws RepositoryException {
-        while (references.hasNext()) {
-            JCRPropertyWrapper reference = (JCRPropertyWrapper) references.nextProperty();
+        // Every reference property is read out of the repository whether or not the caller may see the node holding
+        // it, so each is charged to the request's node allowance as it is pulled, before the permission filter below.
+        // The collected items lead straight back to GqlJcrNode (node/refNode/refNodes fields), where a selection can
+        // nest and fan out again.
+        @SuppressWarnings("unchecked")
+        Iterator<JCRPropertyWrapper> charged = PaginationHelper.chargeToRequestBudget(
+                StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRPropertyWrapper>) references, Spliterator.ORDERED), false),
+                environment).iterator();
+        while (charged.hasNext()) {
+            JCRPropertyWrapper reference = charged.next();
             JCRNodeWrapper referencingNode = reference.getParent();
             if (PermissionHelper.hasPermission(referencingNode, environment)) {
                 String name = reference.getName();
@@ -718,8 +726,15 @@ public class GqlJcrNodeImpl implements GqlJcrNode {
     }
 
     private void collectUsages(PropertyIterator references, Collection<GqlUsage> gqlReferences, DataFetchingEnvironment environment) throws RepositoryException {
-        while (references.hasNext()) {
-            JCRPropertyWrapper reference = (JCRPropertyWrapper) references.nextProperty();
+        // Charged like collectReferences above: every referencing property costs a read before the permission filter
+        // can drop it, and each GqlUsage exposes its node as a field, so a selection can nest through usages back
+        // into GqlJcrNode connections.
+        @SuppressWarnings("unchecked")
+        Iterator<JCRPropertyWrapper> charged = PaginationHelper.chargeToRequestBudget(
+                StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRPropertyWrapper>) references, Spliterator.ORDERED), false),
+                environment).iterator();
+        while (charged.hasNext()) {
+            JCRPropertyWrapper reference = charged.next();
             JCRNodeWrapper referencingNode = reference.getParent();
             if (PermissionHelper.hasPermission(referencingNode, environment)) {
                 String name = reference.getName();

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/NodeHelper.java
@@ -246,7 +246,13 @@ public class NodeHelper {
     public static DXPaginatedData<GqlJcrNode> getPaginatedNodesList(NodeIterator it, Collection<String> names, GqlJcrNode.NodeTypesInput typesFilter, GqlJcrNode.NodePropertiesInput propertiesFilter, FieldFiltersInput fieldFilter,
             DataFetchingEnvironment environment, FieldSorterInput fieldSorterInput, FieldGroupingInput fieldGroupingInput) {
 
-        @SuppressWarnings("unchecked") Stream<GqlJcrNode> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRNodeWrapper>)it, Spliterator.ORDERED), false)
+        @SuppressWarnings("unchecked") Stream<JCRNodeWrapper> nodes = StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRNodeWrapper>)it, Spliterator.ORDERED), false);
+
+        // Charge every node this connection pulls out of the repository against the request's allowance, before any
+        // filter has had the chance to drop one: a node that is read and then filtered out still cost a read, so
+        // charging only the survivors would let a never-matching typesFilter walk a whole subtree for free at every
+        // level of a nested selection - which is the shape the allowance exists to bound.
+        Stream<GqlJcrNode> stream = PaginationHelper.chargeToRequestBudget(nodes, environment)
             .filter(node-> PermissionHelper.hasPermission(node, environment))
             .filter(getNodesPredicate(names, typesFilter, propertiesFilter, null, environment))
             .filter(ThrowingPredicate.unchecked(NodeHelper::checkNodeValidity))

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/DXRelay.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/DXRelay.java
@@ -61,11 +61,14 @@ public class DXRelay extends Relay {
             .field(newFieldDefinition()
                     .name("nodesCount")
                     .type(GraphQLInt)
-                    .description("When paginating forwards, the cursor to continue."))
+                    .description("The number of nodes returned in this page."))
             .field(newFieldDefinition()
                     .name("totalCount")
                     .type(GraphQLInt)
-                    .description("When paginating forwards, the cursor to continue."))
+                    .description("The total number of items the connection matches, ignoring pagination. Computing it"
+                            + " reads every item the connection matches, however small the requested page, and those"
+                            + " reads count against the per-request node limit - omit this field when the total is not"
+                            + " needed."))
             .build();
 
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelper.java
@@ -21,6 +21,7 @@ import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.commons.lang.mutable.MutableObject;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
+import org.jahia.modules.graphql.provider.dxm.GqlLimitExceededException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrWrongInputException;
 import org.jahia.modules.graphql.provider.dxm.util.StreamUtils;
 import org.slf4j.Logger;
@@ -36,6 +37,25 @@ public class PaginationHelper {
 
     private static Logger logger = org.slf4j.LoggerFactory.getLogger(PaginationHelper.class);
     private static AtomicInteger nodeLimit = new AtomicInteger(5000);
+
+    /**
+     * Default number of nodes one request may walk across every connection it selects, together.
+     * <p>
+     * Four times {@link #nodeLimit}, so a request can legitimately page through several connections in full, while a
+     * document that nests connections stays bounded: the per-connection limit caps each connection on its own, never
+     * their product, and it is the product that a nested selection multiplies out. Like the mutation batch limit this
+     * is a starting point rather than a measured figure - it is wide enough that observed traffic does not approach it,
+     * and is expected to be tightened once there is data on real request sizes.
+     */
+    public static final int DEFAULT_REQUEST_NODE_LIMIT = 20000;
+
+    private static AtomicInteger requestNodeLimit = new AtomicInteger(DEFAULT_REQUEST_NODE_LIMIT);
+
+    /**
+     * Key under which a request's remaining node allowance is held in the GraphQL context, seeded once per operation by
+     * {@code QueryCostInstrumentation} and drawn down by every connection the operation resolves.
+     */
+    public static final String REMAINING_NODE_ALLOWANCE = "jahiaRemainingNodeAllowance";
 
     private PaginationHelper() {
     }
@@ -177,6 +197,74 @@ public class PaginationHelper {
 
     public static int getNodeLimit() {
         return nodeLimit.get();
+    }
+
+    /**
+     * Updates the number of nodes one request may walk in total. Called by {@code DXGraphQLConfig} when the
+     * configuration changes; {@code 0} disables the bound.
+     */
+    public static void updateRequestLimit(int limit) {
+        logger.info("Request node limit has been updated to {}", limit);
+        requestNodeLimit.set(limit);
+    }
+
+    /**
+     * @return the configured number of nodes one request may walk across all of its connections; {@code 0} means
+     *         unbounded
+     */
+    public static int getRequestNodeLimit() {
+        return requestNodeLimit.get();
+    }
+
+    /**
+     * Charges every node the given stream yields to the request's node allowance, failing the request once it is spent.
+     * <p>
+     * Applied to a lazy stream of JCR nodes <em>before</em> anything that consumes it, so that one charge covers each of
+     * the ways a connection walks its source: the page {@link #collectItems} collects, the tail
+     * {@link StreamBasedDXPaginatedData#getTotalCount()} drains to count, and any full materialization a sorter or a
+     * grouping imposes ahead of pagination. Each of those pulls through this stage exactly once per node, so nodes are
+     * charged once however the connection ends up reading them.
+     * <p>
+     * The connection that exhausts the allowance fails, so that the response says plainly that it is incomplete rather
+     * than quietly returning a differently-shaped answer - which is what truncating it would do, since the allowance
+     * runs out part-way through whichever connection happens to be resolving at the time. Every connection after that
+     * one reads nothing and reports nothing. Repeating the failure would be its own amplification: the offending
+     * document is one that nests connections, so it has a connection per node the level above it returned, and an error
+     * object apiece turns a bound meant to shrink an over-large response into a way to demand a much larger one. One
+     * error is what a caller needs to know the request was refused; thousands of copies of it are what an attacker
+     * wants.
+     *
+     * @param stream      the nodes a connection is about to read
+     * @param environment the environment carrying the request's remaining allowance
+     * @return the stream, charging as it is consumed; the argument unchanged when no bound is in force
+     */
+    public static <T> Stream<T> chargeToRequestBudget(Stream<T> stream, DataFetchingEnvironment environment) {
+        AtomicInteger remaining = remainingNodeAllowance(environment);
+        if (remaining == null) {
+            return stream;
+        }
+        if (remaining.get() < 0) {
+            // Already spent, and the connection that spent it has already said so.
+            return Stream.empty();
+        }
+        return stream.peek(node -> {
+            if (remaining.decrementAndGet() < 0) {
+                throw new GqlLimitExceededException("This request asked for more than " + getRequestNodeLimit()
+                        + " nodes across all its fields, which is the maximum allowed. Request fewer nodes, either by"
+                        + " paginating with first/limit or by nesting fewer levels of child or descendant fields.");
+            }
+        });
+    }
+
+    /**
+     * @return the request's remaining node allowance, or {@code null} when the bound is disabled or there is no request
+     *         context to hold it (a directly-invoked data fetcher, as in a unit test)
+     */
+    private static AtomicInteger remainingNodeAllowance(DataFetchingEnvironment environment) {
+        if (environment == null || environment.getGraphQlContext() == null) {
+            return null;
+        }
+        return environment.getGraphQlContext().get(REMAINING_NODE_ALLOWANCE);
     }
 
     public static Arguments parseArguments(DataFetchingEnvironment environment) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelper.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelper.java
@@ -250,8 +250,9 @@ public class PaginationHelper {
         return stream.peek(node -> {
             if (remaining.decrementAndGet() < 0) {
                 throw new GqlLimitExceededException("This request asked for more than " + getRequestNodeLimit()
-                        + " nodes across all its fields, which is the maximum allowed. Request fewer nodes, either by"
-                        + " paginating with first/limit or by nesting fewer levels of child or descendant fields.");
+                        + " nodes across all its fields, which is the maximum allowed. Request fewer nodes by"
+                        + " paginating with first/limit, by nesting fewer levels of child or descendant fields, or by"
+                        + " omitting totalCount, which reads everything a connection matches in order to count it.");
             }
         });
     }

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/SDLPaginatedDataConnectionFetcher.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/sdl/fetchers/SDLPaginatedDataConnectionFetcher.java
@@ -43,7 +43,9 @@ public class SDLPaginatedDataConnectionFetcher<T> implements ConnectionFetcher<T
 
     @Override
     public Connection<T> get(DataFetchingEnvironment environment) throws Exception {
-        Stream<T> l = (Stream<T>) fetcher.getStream(environment);
+        // SDL finders run JCR queries and return full GqlJcrNode instances, whose connections a selection can nest
+        // into, so their reads draw on the same per-request node allowance as the built-in connections.
+        Stream<T> l = PaginationHelper.chargeToRequestBudget((Stream<T>) fetcher.getStream(environment), environment);
         PaginationHelper.Arguments arguments = PaginationHelper.parseArguments(environment);
         DXPaginatedData<T> paginatedData = PaginationHelper.paginate(l, n -> PaginationHelper.encodeCursor(((GqlJcrNode)n).getUuid()), arguments);
 

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerReadService.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/tags/service/TagManagerReadService.java
@@ -34,18 +34,23 @@ import org.jahia.services.query.ScrollableQuery;
 import org.jahia.services.query.ScrollableQueryCallback;
 import org.jahia.services.tags.TaggingService;
 import org.osgi.service.component.annotations.Component;
+import pl.touk.throwing.ThrowingFunction;
 
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 
 
@@ -112,7 +117,12 @@ public class TagManagerReadService {
             if (fieldSorter != null) {
                 allTags.sort(SorterHelper.getFieldComparator(fieldSorter, FieldEvaluator.forConnection(environment)));
             }
-            return PaginationHelper.paginate(allTags, tag -> PaginationHelper.encodeCursor(tag.getName()), PaginationHelper.parseArguments(environment));
+            // The returned tags are charged to the request's node allowance like any connection's items. The site
+            // scan behind them deliberately is not: it is batched, aggregates to one small DTO per distinct tag, and
+            // offers nothing node-valued to nest on, so it cannot amplify - whereas charging it would refuse the tag
+            // manager outright on any site holding more tagged nodes than the allowance.
+            return PaginationHelper.paginate(PaginationHelper.chargeToRequestBudget(allTags.stream(), environment),
+                    tag -> PaginationHelper.encodeCursor(tag.getName()), PaginationHelper.parseArguments(environment));
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
@@ -127,7 +137,8 @@ public class TagManagerReadService {
      * {@link JCRContentUtils#sqlEncode(String)}. Matching nodes are sorted by their JCR path
      * for deterministic ordering, then converted to {@link GqlJcrNode} representations via
      * {@link SpecializedTypesHandler} before pagination is applied. Only the {@code default}
-     * (edit) workspace is queried.
+     * (edit) workspace is queried. Every match is charged against the per-request node allowance
+     * as it is read, and the connection is subject to the per-connection node limit.
      *
      * @param siteKey     the Jahia site identifier; must not be {@code null}; the current user
      *                    must hold the {@code tagManager} permission on
@@ -154,11 +165,17 @@ public class TagManagerReadService {
             jcrQuery.bindValue("tag", session.getValueFactory().createValue(tag));
             NodeIterator nodeIterator = jcrQuery.execute().getNodes();
 
-            List<GqlJcrNode> nodes = new ArrayList<>();
-            while (nodeIterator.hasNext()) {
-                nodes.add(SpecializedTypesHandler.getNode((JCRNodeWrapper) nodeIterator.nextNode()));
-            }
-            nodes.sort(Comparator.comparing(gqlNode -> gqlNode.getNode().getPath()));
+            // Charge every match to the request's node allowance as it is read: the query is unbounded, the sort
+            // below reads it in full whatever page was asked for, and the results are full GqlJcrNode instances whose
+            // own connections can nest - the amplification shape the allowance exists to bound. Streaming (rather
+            // than collecting a list) also puts this connection under the per-connection node limit that every other
+            // connection observes.
+            @SuppressWarnings("unchecked")
+            Stream<JCRNodeWrapper> matches = StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize((Iterator<JCRNodeWrapper>) nodeIterator, Spliterator.ORDERED), false);
+            Stream<GqlJcrNode> nodes = PaginationHelper.chargeToRequestBudget(matches, environment)
+                    .map(ThrowingFunction.unchecked(SpecializedTypesHandler::getNode))
+                    .sorted(Comparator.comparing(gqlNode -> gqlNode.getNode().getPath()));
 
             return PaginationHelper.paginate(nodes, gqlNode -> PaginationHelper.encodeCursor(gqlNode.getUuid()), PaginationHelper.parseArguments(environment));
         } catch (RepositoryException e) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/vanity/VanityUrlJCRSiteExtensions.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/service/vanity/VanityUrlJCRSiteExtensions.java
@@ -121,7 +121,11 @@ public class VanityUrlJCRSiteExtensions {
                     "ISDESCENDANTNODE('/sites/" + JCRContentUtils.sqlEncode(siteNode.getSiteKey()) + "')";
             Query query = jcrSession.getWorkspace().getQueryManager().createQuery(vanityQuery, Query.JCR_SQL2);
             NodeIterator it = query.execute().getNodes();
-            Stream<GqlJcrVanityUrl> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRNodeWrapper>)it, Spliterator.ORDERED), false)
+            // Charged although the extension is currently disabled, so that re-enabling it cannot reopen an
+            // uncharged, unbounded site-wide read.
+            Stream<GqlJcrVanityUrl> stream = PaginationHelper.chargeToRequestBudget(
+                            StreamSupport.stream(Spliterators.spliteratorUnknownSize((Iterator<JCRNodeWrapper>) it, Spliterator.ORDERED), false),
+                            environment)
                     .map(GqlJcrVanityUrl::new);
 
             return PaginationHelper.paginate(stream, v -> PaginationHelper.encodeCursor(v.getUuid()), arguments);

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlGroup.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlGroup.java
@@ -95,7 +95,8 @@ public class GqlGroup implements GqlPrincipal {
                                                     @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,
                                                     @GraphQLName("fieldGrouping") @GraphQLDescription("Group fields according to specified criteria") FieldGroupingInput fieldGrouping,
                                                     DataFetchingEnvironment environment) {
-        Stream<GqlPrincipal> stream = groupManagerService.lookupGroupByPath(group.getLocalPath()).getMembers().stream()
+        Stream<GqlPrincipal> stream = PaginationHelper.chargeToRequestBudget(
+                        groupManagerService.lookupGroupByPath(group.getLocalPath()).getMembers().stream(), environment)
                 .map(this::convertMember)
                 .filter(Objects::nonNull)
                 .filter(FilterHelper.getFieldPredicate(fieldFilter, FieldEvaluator.forConnection(environment)));

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlPrincipal.java
@@ -46,7 +46,10 @@ public interface GqlPrincipal {
                                                         DataFetchingEnvironment environment, JahiaGroupManagerService groupManagerService) {
 
         List<String> paths = groupManagerService.getMembershipByPath(localPath);
-        Stream<GqlGroup> stream = paths.stream()
+        // Charged before the lookups and filters below, since each path costs a group read whether or not a filter
+        // later drops it - and the groups returned carry members and groupMembership connections to nest on, which
+        // must draw on the request's shared allowance.
+        Stream<GqlGroup> stream = PaginationHelper.chargeToRequestBudget(paths.stream(), environment)
                 .map(groupManagerService::lookupGroupByPath)
                 .filter(Objects::nonNull)
                 .map(JCRGroupNode::getJahiaGroup)

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUserAdmin.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/user/GqlUserAdmin.java
@@ -58,8 +58,10 @@ public class GqlUserAdmin {
                                              @GraphQLName("fieldSorter") @GraphQLDescription("Sort by graphQL fields values") FieldSorterInput fieldSorter,
                                              @GraphQLName("fieldGrouping") @GraphQLDescription("Group fields according to specified criteria") FieldGroupingInput fieldGrouping,
                                              DataFetchingEnvironment environment) {
-        Stream<GqlUser> userStream = userManagerService.searchUsers(null)
-                .stream()
+        // The search is unbounded - every user of every provider - so each result is charged to the request's node
+        // allowance before the field filter can drop it, like any other connection's items.
+        Stream<GqlUser> userStream = PaginationHelper.chargeToRequestBudget(
+                        userManagerService.searchUsers(null).stream(), environment)
                 .map(user -> new GqlUser(user.getJahiaUser()))
                 .filter(FilterHelper.getFieldPredicate(fieldFilter, FieldEvaluator.forConnection(environment)));
 

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -41,7 +41,7 @@ graphql.fields.node.limit = 5000
 #
 # The two are not interchangeable. graphql.fields.node.limit caps each connection on its own and says nothing about how
 # many connections a request may open, whereas a nested selection opens one inner connection per node the outer one
-# returns. Set 0 to disable the bound. xs
+# returns. Set 0 to disable the bound.
 graphql.fields.node.requestLimit = 20000
 
 # Query-cost guards (defence against amplification / DoS).

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -35,6 +35,15 @@
 # http.cors.allow-origin=http://mysite1.com, http://mysite2.com
 graphql.fields.node.limit = 5000
 
+# Maximum number of nodes ONE REQUEST may walk across all of its fields together, as opposed to the per-connection cap
+# above. Read only from this default configuration file, like the other limits below, so that a third-party module
+# cannot loosen it.
+#
+# The two are not interchangeable. graphql.fields.node.limit caps each connection on its own and says nothing about how
+# many connections a request may open, whereas a nested selection opens one inner connection per node the outer one
+# returns. Set 0 to disable the bound. xs
+graphql.fields.node.requestLimit = 20000
+
 # Query-cost guards (defence against amplification / DoS).
 # The graphql-java parser caps (grammar depth, token count) only bound the textual shape of a document, not the work
 # it triggers: a query can stay under those caps yet still expand into thousands of resolver invocations. The guards
@@ -52,11 +61,13 @@ graphql.fields.node.limit = 5000
 # Neither guard bounds how far a query's list fields fan out, which is the dimension along which cost multiplies
 # rather than adds: a list nested inside a list is evaluated once per item of the outer one, so
 # descendants { nodes { descendants { nodes { ... } } } } can stand for millions of JCR reads while staying textually
-# small and shallow. That is bounded per connection at execution time by graphql.fields.node.limit above, which caps
-# each connection on its own rather than their product. Bounding the product before execution would need a per-field
-# notion of how many items a field can return, which the schema does not carry: nodeTypes { nodes { extends { nodes } } }
-# is the same shape over connections with the same arguments, yet it reads a few hundred node type definitions out of
-# an in-memory registry rather than millions of nodes.
+# small and shallow. Neither guard CAN bound it, because bounding it before execution would need a per-field notion of
+# how many items a field can return, which the schema does not carry: nodeTypes { nodes { extends { nodes } } } is the
+# same shape over connections with the same arguments, yet it reads a few hundred node type definitions out of an
+# in-memory registry rather than millions of nodes. Any threshold that rejected the second would reject the first.
+# Fan-out is therefore bounded as it happens rather than in advance, by graphql.fields.node.requestLimit above, which
+# counts the nodes a request actually reads - a measure that tells those two documents apart precisely because it does
+# not have to predict them.
 #
 # Mutation fields are bounded on a third axis again — how many nodes one request may ask them to operate on — by
 # graphql.mutation.batch.limit below. That is a property of the arguments a field is handed rather than of the

--- a/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
+++ b/graphql-dxm-provider/src/main/resources/META-INF/configurations/org.jahia.modules.graphql.provider-default.cfg
@@ -42,6 +42,11 @@ graphql.fields.node.limit = 5000
 # The two are not interchangeable. graphql.fields.node.limit caps each connection on its own and says nothing about how
 # many connections a request may open, whereas a nested selection opens one inner connection per node the outer one
 # returns. Set 0 to disable the bound.
+#
+# Note that a connection's totalCount is computed by reading every item the connection matches, however small the
+# requested page, and those reads are charged like any other: selecting totalCount over a result set larger than this
+# limit is the most likely way for a legitimate client to reach it. Such clients should omit totalCount where the
+# total is not actually shown; deployments that need large counts can raise the limit.
 graphql.fields.node.requestLimit = 20000
 
 # Query-cost guards (defence against amplification / DoS).

--- a/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/config/DXGraphQLConfigTest.java
+++ b/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/config/DXGraphQLConfigTest.java
@@ -44,6 +44,7 @@ public class DXGraphQLConfigTest {
     private static final String DEFAULT_CONFIG_PID = "org.jahia.modules.graphql.provider~default";
 
     private static final int DEFAULT_NODE_LIMIT = 5000;
+    private static final int DEFAULT_REQUEST_NODE_LIMIT = 20000;
 
     private DXGraphQLConfig config;
 
@@ -122,6 +123,46 @@ public class DXGraphQLConfigTest {
         assertEquals(2000, config.getMaxQueryComplexity());
         assertEquals(30, config.getMaxQueryDepth());
         assertEquals(100, config.getNodeLimit());
+    }
+
+    // --- the per-request node allowance, which unlike the guards above is on by default ---
+
+    @Test
+    public void shouldBoundNodesPerRequestByDefault() {
+        // The allowance is what bounds nested fan-out, so it has to hold with no configuration present at all: unlike
+        // the complexity and depth guards, whose code default is 0, an absent property must not leave it unbounded.
+        assertEquals(DEFAULT_REQUEST_NODE_LIMIT, config.getRequestNodeLimit());
+    }
+
+    @Test
+    public void shouldApplyRequestNodeLimitFromDefaultConfig() throws ConfigurationException {
+        config.updated("pid1", props(DEFAULT_CONFIG_FILE, "graphql.fields.node.requestLimit", "250"));
+
+        assertEquals(250, config.getRequestNodeLimit());
+    }
+
+    @Test
+    public void shouldIgnoreRequestNodeLimitFromNonDefaultConfig() throws ConfigurationException {
+        config.updated("pid1", props(OTHER_CONFIG_FILE, "graphql.fields.node.requestLimit", "1000000"));
+
+        assertEquals(DEFAULT_REQUEST_NODE_LIMIT, config.getRequestNodeLimit());
+    }
+
+    @Test
+    public void shouldRevertRequestNodeLimitWhenPropertyRemoved() throws ConfigurationException {
+        config.updated("pid1", props(DEFAULT_CONFIG_FILE, "graphql.fields.node.requestLimit", "250"));
+        assertEquals(250, config.getRequestNodeLimit());
+
+        config.updated("pid1", props(DEFAULT_CONFIG_FILE));
+
+        assertEquals(DEFAULT_REQUEST_NODE_LIMIT, config.getRequestNodeLimit());
+    }
+
+    @Test
+    public void shouldTreatZeroRequestNodeLimitAsUnbounded() throws ConfigurationException {
+        config.updated("pid1", props(DEFAULT_CONFIG_FILE, "graphql.fields.node.requestLimit", "0"));
+
+        assertEquals(0, config.getRequestNodeLimit());
     }
 
     @Test

--- a/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelperTest.java
+++ b/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelperTest.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Unit tests for the per-request node allowance, the bound that stops a document nesting connections from expanding
@@ -68,13 +68,10 @@ public class PaginationHelperTest {
 
         Stream<String> charged = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment);
 
-        try {
-            charged.collect(Collectors.toList());
-            fail("expected the request to be refused once it had walked more nodes than its allowance");
-        } catch (GqlLimitExceededException e) {
-            // Refused on the node that would have taken it past the allowance, not at the end of the walk.
-            assertEquals(-1, allowanceOf(environment).get());
-        }
+        assertThrows(GqlLimitExceededException.class, () -> charged.collect(Collectors.toList()));
+
+        // Refused on the node that would have taken it past the allowance, not at the end of the walk.
+        assertEquals(-1, allowanceOf(environment).get());
     }
 
     @Test
@@ -112,12 +109,12 @@ public class PaginationHelperTest {
         PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
         assertEquals(2, allowanceOf(environment).get());
 
-        try {
-            PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
-            fail("expected the second connection to be refused, having only the rest of the request's allowance");
-        } catch (GqlLimitExceededException e) {
-            assertEquals(-1, allowanceOf(environment).get());
-        }
+        // The second connection has only what the first left, not a fresh per-connection limit.
+        Stream<String> secondConnection = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment);
+
+        assertThrows(GqlLimitExceededException.class, () -> secondConnection.collect(Collectors.toList()));
+
+        assertEquals(-1, allowanceOf(environment).get());
     }
 
     @Test
@@ -128,13 +125,11 @@ public class PaginationHelperTest {
         // thing an amplification attack is after. One refusal is what a caller needs.
         DataFetchingEnvironment environment = environmentWithAllowance(2);
 
-        try {
-            PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
-            fail("expected the connection that spends the allowance to report it");
-        } catch (GqlLimitExceededException expected) {
-            // The request has been told once; from here on the remaining connections stay silent.
-        }
+        Stream<String> spendingConnection = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment);
 
+        assertThrows(GqlLimitExceededException.class, () -> spendingConnection.collect(Collectors.toList()));
+
+        // The request has been told once; from here on the remaining connections stay silent.
         List<String> read = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment)
                 .collect(Collectors.toList());
 

--- a/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelperTest.java
+++ b/graphql-dxm-provider/src/test/java/org/jahia/modules/graphql/provider/dxm/relay/PaginationHelperTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.graphql.provider.dxm.relay;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import org.jahia.modules.graphql.provider.dxm.GqlLimitExceededException;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for the per-request node allowance, the bound that stops a document nesting connections from expanding
+ * into an unbounded walk of the repository.
+ */
+public class PaginationHelperTest {
+
+    private static final List<String> NODES = Arrays.asList("a", "b", "c", "d", "e");
+
+    private static DataFetchingEnvironment environmentWithAllowance(Integer allowance) {
+        GraphQLContext context = GraphQLContext.newContext().build();
+        if (allowance != null) {
+            context.put(PaginationHelper.REMAINING_NODE_ALLOWANCE, new AtomicInteger(allowance));
+        }
+        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment().graphQLContext(context).build();
+    }
+
+    private static AtomicInteger allowanceOf(DataFetchingEnvironment environment) {
+        return environment.getGraphQlContext().get(PaginationHelper.REMAINING_NODE_ALLOWANCE);
+    }
+
+    @Test
+    public void shouldPassEveryNodeThroughUnchangedWhileAllowanceLasts() {
+        DataFetchingEnvironment environment = environmentWithAllowance(NODES.size());
+
+        List<String> read = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment)
+                .collect(Collectors.toList());
+
+        assertEquals(NODES, read);
+        assertEquals(0, allowanceOf(environment).get());
+    }
+
+    @Test
+    public void shouldFailTheRequestOnceTheAllowanceIsSpent() {
+        DataFetchingEnvironment environment = environmentWithAllowance(3);
+
+        Stream<String> charged = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment);
+
+        try {
+            charged.collect(Collectors.toList());
+            fail("expected the request to be refused once it had walked more nodes than its allowance");
+        } catch (GqlLimitExceededException e) {
+            // Refused on the node that would have taken it past the allowance, not at the end of the walk.
+            assertEquals(-1, allowanceOf(environment).get());
+        }
+    }
+
+    @Test
+    public void shouldNotBoundAnythingWhenNoAllowanceIsInContext() {
+        // 0 in the configuration means unbounded, which reaches here as an absent allowance.
+        DataFetchingEnvironment environment = environmentWithAllowance(null);
+
+        List<String> read = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment)
+                .collect(Collectors.toList());
+
+        assertEquals(NODES, read);
+        assertNull(allowanceOf(environment));
+    }
+
+    @Test
+    public void shouldChargeOnlyTheNodesActuallyRead() {
+        // A connection asked for one page does not walk the whole subtree, and must not be charged as though it had:
+        // the allowance is spent on nodes read, so it has to be charged as they are pulled, not up front.
+        DataFetchingEnvironment environment = environmentWithAllowance(NODES.size());
+
+        List<String> read = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment)
+                .limit(2)
+                .collect(Collectors.toList());
+
+        assertEquals(Arrays.asList("a", "b"), read);
+        assertEquals(NODES.size() - 2, allowanceOf(environment).get());
+    }
+
+    @Test
+    public void shouldDrawEveryConnectionOfARequestFromTheOneAllowance() {
+        // The point of the bound: a nested selection opens one inner connection per node the outer one returned, and
+        // each of those is within the per-connection limit. Only a shared allowance bounds their product.
+        DataFetchingEnvironment environment = environmentWithAllowance(7);
+
+        PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
+        assertEquals(2, allowanceOf(environment).get());
+
+        try {
+            PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
+            fail("expected the second connection to be refused, having only the rest of the request's allowance");
+        } catch (GqlLimitExceededException e) {
+            assertEquals(-1, allowanceOf(environment).get());
+        }
+    }
+
+    @Test
+    public void shouldReadNothingAndRaiseNothingOnceTheRefusalHasBeenReported() {
+        // The documents this bound refuses are the ones that nest connections, so they hold a connection per node the
+        // level above returned. Raising the failure again in each of them would answer a request meant to be cut down
+        // with an error object per connection - a far bigger response than the one being refused, which is the very
+        // thing an amplification attack is after. One refusal is what a caller needs.
+        DataFetchingEnvironment environment = environmentWithAllowance(2);
+
+        try {
+            PaginationHelper.chargeToRequestBudget(NODES.stream(), environment).collect(Collectors.toList());
+            fail("expected the connection that spends the allowance to report it");
+        } catch (GqlLimitExceededException expected) {
+            // The request has been told once; from here on the remaining connections stay silent.
+        }
+
+        List<String> read = PaginationHelper.chargeToRequestBudget(NODES.stream(), environment)
+                .collect(Collectors.toList());
+
+        assertEquals(0, read.size());
+    }
+}

--- a/tests/cypress/e2e/api/requestNodeLimit.cy.ts
+++ b/tests/cypress/e2e/api/requestNodeLimit.cy.ts
@@ -15,6 +15,10 @@ import gql from 'graphql-tag';
  * served and the second refused - so a pass and a failure here differ only in nesting, which is precisely the dimension
  * the per-connection limit cannot see: every connection in either query is far below graphql.fields.node.limit.
  *
+ * Selecting pageInfo.totalCount reads every node the connection matches regardless of the page size, and those reads
+ * are charged like any other. The totalCount tests pin that down with the allowance at 100: a one-item page over the
+ * 155-node subtree passes without totalCount and is refused with it.
+ *
  * Only honoured from the default provider configuration, so the limit is driven through a groovy provisioning fixture
  * that edits the "default" factory instance (see setRequestNodeLimit.groovy). Config propagation (ConfigAdmin update
  * -> ManagedServiceFactory.updated) is asynchronous, so we poll until the new value takes effect rather than waiting a
@@ -33,6 +37,35 @@ describe('GraphQL per-request node allowance', () => {
             jcr {
                 nodeByPath(path: "${TEST_ROOT}") {
                     descendants {
+                        nodes { name }
+                    }
+                }
+            }
+        }
+    `;
+
+    // A one-item page over the same subtree, but selecting totalCount: computing the total reads every node the
+    // connection matches, however small the page, and those reads are charged like any other. With the allowance
+    // below the subtree size this is refused - the page alone would cost 2 nodes.
+    const totalCountQuery = gql`
+        query {
+            jcr {
+                nodeByPath(path: "${TEST_ROOT}") {
+                    descendants(first: 1) {
+                        pageInfo { totalCount }
+                        nodes { name }
+                    }
+                }
+            }
+        }
+    `;
+
+    // The same one-item page without totalCount, which only the page itself is charged for.
+    const firstPageOnlyQuery = gql`
+        query {
+            jcr {
+                nodeByPath(path: "${TEST_ROOT}") {
+                    descendants(first: 1) {
                         nodes { name }
                     }
                 }
@@ -121,6 +154,22 @@ describe('GraphQL per-request node allowance', () => {
         waitUntilRejected(nestedQuery);
         cy.apollo({query: nestedQuery, errorPolicy: 'all'}).should((response: any) => {
             expect(response.errors[0].message).to.match(/asked for more than 200 nodes/);
+        });
+    });
+
+    it('charges totalCount for every node the connection matches, not just the page', () => {
+        // 155 matches against an allowance of 100: the one-node page is fine, the count is not.
+        setRequestNodeLimit(100);
+        waitUntilRejected(totalCountQuery);
+    });
+
+    it('serves the same page once totalCount is omitted', () => {
+        setRequestNodeLimit(100);
+        // Rejection of the totalCount variant doubles as proof that the new limit has propagated.
+        waitUntilRejected(totalCountQuery);
+        cy.apollo({query: firstPageOnlyQuery, errorPolicy: 'all'}).should((response: any) => {
+            expect(hasAllowanceError(response?.errors)).to.equal(false);
+            expect(response?.data?.jcr?.nodeByPath?.descendants?.nodes).to.have.length(1);
         });
     });
 

--- a/tests/cypress/e2e/api/requestNodeLimit.cy.ts
+++ b/tests/cypress/e2e/api/requestNodeLimit.cy.ts
@@ -1,0 +1,131 @@
+import gql from 'graphql-tag';
+
+/*
+ * Per-request node allowance (graphql.fields.node.requestLimit).
+ *
+ * graphql.fields.node.limit caps how many nodes ONE connection collects. It says nothing about how many connections a
+ * request may open, and a nested selection opens one inner connection per node the outer one returned - so the work a
+ * request does is the product of those caps, not the largest of them. A document nesting `descendants` is textually
+ * small and shallow, passes maxComplexity and maxDepth comfortably, and still stands for an unbounded walk; a few in
+ * parallel are enough to exhaust a server's heap. This bound is what closes that: the allowance is shared by every
+ * field of the request and spent as nodes are actually read.
+ *
+ * The tests below are built around a fixture subtree of 155 nodes (three levels of five). Walking it once reads 155
+ * nodes; walking it with `descendants` nested one level deeper reads 430. With the allowance set to 200 the first is
+ * served and the second refused - so a pass and a failure here differ only in nesting, which is precisely the dimension
+ * the per-connection limit cannot see: every connection in either query is far below graphql.fields.node.limit.
+ *
+ * Only honoured from the default provider configuration, so the limit is driven through a groovy provisioning fixture
+ * that edits the "default" factory instance (see setRequestNodeLimit.groovy). Config propagation (ConfigAdmin update
+ * -> ManagedServiceFactory.updated) is asynchronous, so we poll until the new value takes effect rather than waiting a
+ * fixed delay.
+ */
+describe('GraphQL per-request node allowance', () => {
+    const waitOptions = {interval: 500, timeout: 30000};
+
+    // The shipped default, restored after the suite so later specs are unaffected.
+    const SHIPPED_REQUEST_NODE_LIMIT = 20000;
+    const TEST_ROOT = '/sites/systemsite/contents/requestNodeLimitTest';
+
+    // Walks the fixture subtree once: 155 nodes, comfortably inside an allowance of 200.
+    const oneLevelQuery = gql`
+        query {
+            jcr {
+                nodeByPath(path: "${TEST_ROOT}") {
+                    descendants {
+                        nodes { name }
+                    }
+                }
+            }
+        }
+    `;
+
+    // The same subtree, one level of nesting deeper. Every individual connection stays far below
+    // graphql.fields.node.limit; it is their product that runs past the allowance.
+    const nestedQuery = gql`
+        query {
+            jcr {
+                nodeByPath(path: "${TEST_ROOT}") {
+                    descendants {
+                        nodes {
+                            name
+                            descendants {
+                                nodes { name }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    const setRequestNodeLimit = (limit: number) => {
+        cy.executeGroovy('groovy/setRequestNodeLimit.groovy', {REQUEST_NODE_LIMIT: String(limit)});
+    };
+
+    const hasAllowanceError = (errors: any[]) =>
+        Boolean(errors?.some((e: any) => e.message.includes('which is the maximum allowed')));
+
+    // Poll until the query is refused for exceeding the allowance (the new value has propagated).
+    const waitUntilRejected = (query: any) => {
+        cy.waitUntil(
+            () => cy.apollo({query, errorPolicy: 'all'}).then((r: any) => hasAllowanceError(r?.errors)),
+            {...waitOptions, errorMsg: 'Query was never refused for exceeding the node allowance'}
+        );
+    };
+
+    // Poll until the query runs without an allowance error AND returns nodes, so that a query which is merely accepted
+    // but answers with nothing does not count as a pass.
+    const waitUntilAccepted = (query: any) => {
+        cy.waitUntil(
+            () => cy.apollo({query, errorPolicy: 'all'}).then((r: any) =>
+                Boolean(r?.data?.jcr?.nodeByPath?.descendants?.nodes?.length) && !hasAllowanceError(r?.errors)),
+            {...waitOptions, errorMsg: 'Query was never accepted after relaxing the allowance'}
+        );
+    };
+
+    before('create the fixture subtree', () => {
+        cy.executeGroovy('groovy/prepareRequestNodeLimitTest.groovy', {});
+    });
+
+    after('restore the shipped default and clean up', () => {
+        setRequestNodeLimit(SHIPPED_REQUEST_NODE_LIMIT);
+        waitUntilAccepted(nestedQuery);
+        cy.apollo({
+            mutation: gql`
+                mutation {
+                    jcr {
+                        mutateNodes(pathsOrIds: ["${TEST_ROOT}"]) {
+                            delete
+                        }
+                    }
+                }
+            `
+        });
+    });
+
+    it('refuses a nested query whose connections are each within the per-connection limit', () => {
+        setRequestNodeLimit(200);
+        waitUntilRejected(nestedQuery);
+    });
+
+    it('still serves the same subtree when it is not nested', () => {
+        setRequestNodeLimit(200);
+        // Same content, same per-connection limit, same depth budget - only the nesting differs, and that is what the
+        // allowance charges for.
+        waitUntilAccepted(oneLevelQuery);
+    });
+
+    it('reports the limit that was hit', () => {
+        setRequestNodeLimit(200);
+        waitUntilRejected(nestedQuery);
+        cy.apollo({query: nestedQuery, errorPolicy: 'all'}).should((response: any) => {
+            expect(response.errors[0].message).to.match(/asked for more than 200 nodes/);
+        });
+    });
+
+    it('applies no bound at all when set to 0', () => {
+        setRequestNodeLimit(0);
+        waitUntilAccepted(nestedQuery);
+    });
+});

--- a/tests/cypress/fixtures/groovy/prepareRequestNodeLimitTest.groovy
+++ b/tests/cypress/fixtures/groovy/prepareRequestNodeLimitTest.groovy
@@ -1,0 +1,39 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRNodeWrapper
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+
+import javax.jcr.RepositoryException
+
+// Builds a small, deterministic subtree for the per-request node allowance test: three levels of five, so the root has
+// 5 + 25 + 125 = 155 descendants.
+//
+// The exact shape matters. Walking the subtree once reads 155 nodes; walking it with `descendants` nested one level
+// deeper reads 430 (155, plus 30 for each of the 5 top folders and 5 for each of the 25 second-level folders). The
+// spec puts the allowance between those two figures, which is what tells a per-request bound apart from the
+// per-connection one - both queries stay far below graphql.fields.node.limit either way.
+//
+// Its own root, rather than the tree preparePaginationNodeLimitTest.groovy builds, so the two specs cannot collide
+// over the same path whatever order they run in.
+JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback() {
+    @Override
+    Object doInJCR(JCRSessionWrapper session) throws RepositoryException {
+        JCRNodeWrapper contents = session.getNode("/sites/systemsite/contents")
+        if (contents.hasNode("requestNodeLimitTest")) {
+            contents.getNode("requestNodeLimitTest").remove()
+            session.save()
+        }
+        JCRNodeWrapper root = contents.addNode("requestNodeLimitTest", "jnt:contentFolder")
+        for (int i = 0; i < 5; i++) {
+            JCRNodeWrapper folder = root.addNode("folder-" + i, "jnt:contentFolder")
+            for (int j = 0; j < 5; j++) {
+                JCRNodeWrapper sub = folder.addNode("sub-" + i + "-" + j, "jnt:contentFolder")
+                for (int k = 0; k < 5; k++) {
+                    sub.addNode("leaf-" + i + "-" + j + "-" + k, "jnt:contentFolder")
+                }
+            }
+        }
+        session.save()
+        return null
+    }
+})

--- a/tests/cypress/fixtures/groovy/setRequestNodeLimit.groovy
+++ b/tests/cypress/fixtures/groovy/setRequestNodeLimit.groovy
@@ -1,0 +1,18 @@
+import org.jahia.osgi.BundleUtils
+import org.osgi.service.cm.ConfigurationAdmin
+
+// Sets the per-request node allowance on the DEFAULT provider configuration.
+//
+// The provider only honours graphql.fields.node.requestLimit when it comes from the default configuration, so that a
+// third-party module config cannot loosen it. It recognises the default configuration by its pid, so editing the
+// existing "default" factory instance via getFactoryConfiguration(...,"default",...) is all that is needed here.
+//
+// Token REQUEST_NODE_LIMIT is substituted by cy.executeGroovy. Use 0 to disable the bound.
+def ca = BundleUtils.getOsgiService(ConfigurationAdmin.class, null)
+def config = ca.getFactoryConfiguration("org.jahia.modules.graphql.provider", "default", null)
+def props = config.getProperties()
+if (props == null) {
+    props = new java.util.Hashtable()
+}
+props.put("graphql.fields.node.requestLimit", "REQUEST_NODE_LIMIT")
+config.update(props)


### PR DESCRIPTION
### Description
This PR adds a limit to the number of documents returned by a single GQL query.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
