### PR TITLE
feat: deprecate notZonedDateValue and NOT_ZONED_DATE

### DIFF
--- a/.chachalog/VSRn7NAz.md
+++ b/.chachalog/VSRn7NAz.md
@@ -1,0 +1,10 @@
+---
+# Allowed version bumps: patch, minor, major
+graphql-core: minor
+---
+
+**Deprecation:** the time-zone-less date surface of JCR properties is deprecated. On `JCRProperty`, `notZonedDateValue` and `notZonedDateValues` are marked `@deprecated`; on the property mutations (`setValue`, `addValue`, etc.), the `NOT_ZONED_DATE` value of the `option` argument is deprecated. All of them keep working exactly as before; nothing is removed.
+
+Prefer the zoned variants: read a date with `value` / `values`, which return the JCR ISO-8601 form carrying the time zone offset, and write one by passing `type: DATE` with an offset-bearing ISO-8601 value and no `option`.
+
+The deprecated surface formats and parses in the _server's_ default time zone and drops the offset, so the same string denotes a different instant depending on where it is read or written. This ambiguity is the reason for deprecation.

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrProperty.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrProperty.java
@@ -15,6 +15,7 @@
  */
 package org.jahia.modules.graphql.provider.dxm.node;
 
+import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
@@ -178,10 +179,13 @@ public class GqlJcrProperty {
     /**
      * @return The value of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS]
      * in case the property is single-valued, null otherwise
+     * @deprecated use {@link #getValue()} instead
      */
+    @Deprecated
     @GraphQLField
     @GraphQLName("notZonedDateValue")
     @GraphQLDescription("The value of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS] in case the property is single-valued, null otherwise")
+    @GraphQLDeprecate("Use value instead, which keeps the ISO-8601 time zone offset. This field renders the date in the server default time zone and drops the offset, so the instant it denotes is ambiguous.")
     public String getNotZonedDateValue() {
         try {
             if (property.isMultiple() || property.getType() != PropertyType.DATE) {
@@ -239,10 +243,13 @@ public class GqlJcrProperty {
     /**
      * @return The values of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS]
      * in case the property is multiple-valued, null otherwise
+     * @deprecated use {@link #getValues()} instead
      */
+    @Deprecated
     @GraphQLField
     @GraphQLName("notZonedDateValues")
     @GraphQLDescription("The values of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS] in case the property is multiple-valued, null otherwise")
+    @GraphQLDeprecate("Use values instead, which keep the ISO-8601 time zone offset. This field renders the dates in the server default time zone and drops the offset, so the instants they denote are ambiguous.")
     public List<String> getNotZonedDateValues() {
         try {
             if (!property.isMultiple() || property.getType() != PropertyType.DATE) {

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrPropertyOption.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/node/GqlJcrPropertyOption.java
@@ -15,10 +15,20 @@
  */
 package org.jahia.modules.graphql.provider.dxm.node;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLName;
 
 @GraphQLName("JCRPropertyOption")
 public enum GqlJcrPropertyOption {
     ENCRYPTED,
+
+    /**
+     * @deprecated pass an offset-bearing ISO-8601 value with no option instead
+     */
+    // graphql-java-annotations' EnumBuilder reads only @GraphQLName and @GraphQLDescription on a constant, so
+    // @GraphQLDeprecate would never reach the schema: the notice has to travel in the description.
+    @Deprecated
+    @GraphQLDescription("Deprecated: set the property with an ISO-8601 value carrying its time zone offset and no option instead. "
+            + "This option reads the value in the server default time zone, so the instant it stores depends on the server.")
     NOT_ZONED_DATE
 }

--- a/tests/schema.graphql
+++ b/tests/schema.graphql
@@ -2591,9 +2591,9 @@ type JCRProperty {
     "The GraphQL representation of the JCR node the property belongs to."
     node: JCRNode!
     "The value of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS] in case the property is single-valued, null otherwise"
-    notZonedDateValue: String
+    notZonedDateValue: String @deprecated(reason: "Use value instead, which keeps the ISO-8601 time zone offset. This field renders the date in the server default time zone and drops the offset, so the instant it denotes is ambiguous.")
     "The values of the JCR property casted as date and returned in this string format: [yyyy-MM-dd'T'HH:mm:ss.SSS] in case the property is multiple-valued, null otherwise"
-    notZonedDateValues: [String]
+    notZonedDateValues: [String] @deprecated(reason: "Use values instead, which keep the ISO-8601 time zone offset. This field renders the dates in the server default time zone and drops the offset, so the instants they denote are ambiguous.")
     "The path of the JCR property"
     path: String!
     "GraphQL representation of the node this property references in case the property is single-valued, null otherwise"
@@ -4453,7 +4453,7 @@ enum GroupingType {
 enum JCRPropertyOption {
     "ENCRYPTED"
     ENCRYPTED
-    "NOT_ZONED_DATE"
+    "Deprecated: set the property with an ISO-8601 value carrying its time zone offset and no option instead. This option reads the value in the server default time zone, so the instant it stores depends on the server."
     NOT_ZONED_DATE
 }
 


### PR DESCRIPTION
### Description

Companion PR https://github.com/Jahia/jcontent/pull/2696

Deprecated not-zoned APIs without changing anything.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
