### PR TITLE
chore(tests): bump graphql-dxm-provider test dependency to 3.9.0-SNAPSHOT

### DIFF
--- a/tests/jahia-module/misc-test-module/pom.xml
+++ b/tests/jahia-module/misc-test-module/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -55,7 +55,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>graphql-core-test-module-root</artifactId>
     <name>GraphQL Core Test Module Root</name>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>3.9.0</version>
     <packaging>pom</packaging>
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -60,7 +60,7 @@
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 
     <properties>
-        <graphql-dxm-provider.version>3.7.0-SNAPSHOT</graphql-dxm-provider.version>
+        <graphql-dxm-provider.version>3.9.0-SNAPSHOT</graphql-dxm-provider.version>
     </properties>
 
     <repositories>

--- a/tests/jahia-module/scheduler-test-module/pom.xml
+++ b/tests/jahia-module/scheduler-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>

--- a/tests/jahia-module/schema-update-test-module/pom.xml
+++ b/tests/jahia-module/schema-update-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>schema-update-test-module</artifactId>

--- a/tests/jahia-module/sdl-test-module/pom.xml
+++ b/tests/jahia-module/sdl-test-module/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>graphql-core-test-module-root</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>


### PR DESCRIPTION
Part of Jahia/graphql-core#647

The 3.9.0 release [workflow run](https://github.com/Jahia/graphql-core/actions/runs/32489482012) failed while releasing the test modules: `misc-test-module` resolves `graphql-dxm-provider` through the `graphql-dxm-provider.version` property in `tests/jahia-module/pom.xml`, which still pinned `3.7.0-SNAPSHOT` — a snapshot that has since been purged from Nexus (it still existed when 3.8.x was released, which is why this never surfaced before).

This bumps the property to `3.9.0-SNAPSHOT`, the current development version published by main-branch CI.

Test-tree-only change — no product code affected, no changelog fragment.