### PR TITLE
fix: apply the graphql scope to GraphQL WebSocket subscription connections

### DIFF
--- a/.chachalog/wsSubscriptionScopeFix.md
+++ b/.chachalog/wsSubscriptionScopeFix.md
@@ -1,0 +1,5 @@
+---
+graphql-core: minor
+---
+
+Fixed GraphQL subscriptions over WebSocket so an authenticated connection is no longer rejected with a permission error.

--- a/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/OsgiGraphQLWsEndpoint.java
+++ b/graphql-dxm-provider/src/main/java/org/jahia/modules/graphql/provider/dxm/OsgiGraphQLWsEndpoint.java
@@ -23,6 +23,7 @@ import org.jahia.api.Constants;
 import org.jahia.osgi.BundleUtils;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.securityfilter.PermissionService;
+import org.jahia.services.securityfilter.ScopeDefinition;
 import org.jahia.services.usermanager.JahiaUser;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -35,9 +36,12 @@ import javax.websocket.*;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpoint;
 import javax.websocket.server.ServerEndpointConfig;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Component(immediate = true, service = Endpoint.class)
 @ServerEndpoint(value="/graphqlws", subprotocols = {"graphql-ws", "graphql-transport-ws"}, configurator = OsgiGraphQLWsEndpoint.Configurator.class)
@@ -109,10 +113,21 @@ public class OsgiGraphQLWsEndpoint extends Endpoint {
 
             // Capture the authorization scopes resolved for this handshake (HTTP) request so the
             // subscription execution thread can restore them (see JahiaSubscriptionExecutionStrategy).
-            // The handshake runs through the servlet filter chain, so the scopes are resolved here.
+            // POC fix: confirmed via PermissionServiceImpl trace logging that the WS upgrade request
+            // (/modules/graphqlws) auto-applies a narrower scope set than a plain /modules/graphql
+            // request - it never includes "graphql", so every subscription field check is denied
+            // regardless of the connecting user's identity. Explicitly fold the "graphql" scope into
+            // whatever this handshake naturally resolved, since a WS connection carrying a GraphQL
+            // subscription is definitionally a graphql API caller.
             PermissionService permissionService = BundleUtils.getOsgiService(PermissionService.class, null);
             if (permissionService != null) {
-                sec.getUserProperties().put(SESSION_SCOPES, permissionService.getCurrentScopes());
+                Collection<ScopeDefinition> currentScopes = permissionService.getCurrentScopes();
+                Set<ScopeDefinition> scopesToCapture = currentScopes != null ? new HashSet<>(currentScopes) : new HashSet<>();
+                permissionService.getAvailableScopes().stream()
+                        .filter(s -> "graphql".equals(s.getScopeName()))
+                        .findFirst()
+                        .ifPresent(scopesToCapture::add);
+                sec.getUserProperties().put(SESSION_SCOPES, scopesToCapture);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #660 — a GraphQL subscription over the WebSocket transport (`/modules/graphqlws`) was rejected with a `GqlAccessDeniedException` ("Permission denied") for any connecting user, including `root`, because the WS handshake never carried the `graphql` authorization scope that a plain `/modules/graphql` HTTP request gets.

## Why

#639 started enforcing the same `PermissionService` scope check on the WebSocket transport as on HTTP (correctly — the check was previously skipped entirely on WS). But the WS upgrade handshake auto-applies a narrower scope set than an equivalent HTTP GraphQL request, and that narrower set never includes `graphql`. So every subscription field access now fails the new check unconditionally, regardless of the caller's identity or privileges. See #660 for the full manual reproduction (curl login + `wscat`) and before/after TRACE log evidence from `PermissionServiceImpl`.

## Changes

- `OsgiGraphQLWsEndpoint.Configurator.modifyHandshake()`: explicitly fold the `graphql` scope (looked up via `PermissionService#getAvailableScopes()`) into whatever scope set the handshake naturally resolved, before capturing it into `SESSION_SCOPES` for the subscription execution thread. A WS connection carrying a GraphQL subscription is definitionally a graphql API caller, so it should carry that scope the same way an HTTP GraphQL request does.
- `.chachalog/wsSubscriptionScopeFix.md`: customer-facing changelog note.

## Validation

- [x] Built `graphql-dxm-provider` locally and deployed it to a running Jahia instance.
- [x] Reproduced the denial before the fix (manual `curl` login + `wscat` subscribe to `backgroundJobSubscription`, `GqlAccessDeniedException` / "Permission denied").
- [x] Confirmed the fix: identical repro against the patched build returns a granted permission check and the subscription's job listener is registered (`PermissionServiceImpl` TRACE log, `GqlJobSubscriptionExtension` "Adding job listener" — see #660 for both log excerpts).
- [ ] Full Cypress suite not re-run against this branch yet.

## Documentation

None needed.

## ADR

None.

## Note on scope of this fix

This folds the `graphql` scope in at the WS endpoint level, which is the minimal, targeted fix. A more thorough fix would instead correct the `graphql` `ScopeDefinition`'s own auto-apply criteria so it matches `/modules/graphqlws` the same way it matches `/modules/graphql`, avoiding the need to special-case the scope name here — flagging that as a possible follow-up rather than blocking this fix on it.
